### PR TITLE
Fixing 2 #import issues for case sensitive development machines

### DIFF
--- a/HabitRPG/TabBarController/HRPGSpellTabBarController.m
+++ b/HabitRPG/TabBarController/HRPGSpellTabBarController.m
@@ -9,7 +9,7 @@
 #import "HRPGSpellTabBarController.h"
 #import "HRPGSpellTaskController.h"
 #import "HRPGAppDelegate.h"
-#import <NIKFontawesomeIconFactory.h>
+#import <NIKFontAwesomeIconFactory.h>
 #import <NIKFontAwesomeIconFactory+iOS.h>
 
 @interface HRPGSpellTabBarController ()

--- a/HabitRPG/Views/HRPGHabitButton.m
+++ b/HabitRPG/Views/HRPGHabitButton.m
@@ -7,7 +7,7 @@
 //
 
 #import "HRPGHabitButton.h"
-#import <POP/POP.h>
+#import <pop/POP.h>
 
 @interface HRPGHabitButton()
 - (void)setup;


### PR DESCRIPTION
If the HabitRPG-iOS code is stored on a case sensitive drive the POP.h
header was not being found, nor the NIKFontAwesomeIconFactory.h due to
the CASE used in the #import statement.