### PR TITLE
DoNotFeedVeteranPets

### DIFF
--- a/HabitRPG/HRPGPetViewController.m
+++ b/HabitRPG/HRPGPetViewController.m
@@ -143,7 +143,7 @@
     } else if ([self.equippedPetName isEqualToString:pet.key]) {
         equipString = NSLocalizedString(@"Unequip", nil);
     }
-    if (pet.asMount) {
+    if ((pet.asMount) || ([pet.type isEqualToString:@" "])){
         feedString = nil;
     }
 


### PR DESCRIPTION
Since Veteran Pets should not have a feeding progress bar they should
not have the option to be fed either.

Added the same check used to remove their progress bar to the code to determine if the Feed option shows up on the ActionSheet.