### PR TITLE
Fix Party UITableViewCells

### DIFF
--- a/HabitRPG/TableViewController/HRPGUserProfileViewController.m
+++ b/HabitRPG/TableViewController/HRPGUserProfileViewController.m
@@ -94,7 +94,6 @@
     if (indexPath.section == 0) {
         switch (indexPath.item) {
             case 0:
-                
                 [self configureCell:cell atIndexPath:indexPath];
                 break;
             case 1: {
@@ -116,6 +115,7 @@
                 break;
         }
     }
+    [cell layoutSubviews];
     return cell;
 }
 

--- a/HabitRPG/TableViewController/Party/HRPGQuestParticipantsViewController.m
+++ b/HabitRPG/TableViewController/Party/HRPGQuestParticipantsViewController.m
@@ -160,6 +160,7 @@ NSString *partyID;
         cell.detailTextLabel.text = NSLocalizedString(@"Declined", nil);
         cell.detailTextLabel.textColor = [UIColor colorWithRed:0.933 green:0.144 blue:0.198 alpha:1.000];
     }
+    [cell layoutSubviews];
 }
 
 


### PR DESCRIPTION
Since we're using the standard `UITableViewCell` we need to inform the cell that it needs to relayout its subviews after we set values. This should fix some small issues where you can't see if party members have accepted, rejected, or pending on a quest as well as their Member Since and Last Logged in date on their profiles.

Here's my UUID: 0fc2a747-acdb-4a89-b646-66d75c232ade

First time contributor! Just started using the application this past week - has been great for my productivity.