### PR TITLE
Pods:  use a Gemfile + lock to manage CocoaPods version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '0.38.2'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,62 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (0.9.1)
+    cocoapods (0.38.2)
+      activesupport (>= 3.2.15)
+      claide (~> 0.9.1)
+      cocoapods-core (= 0.38.2)
+      cocoapods-downloader (~> 0.9.1)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-stats (~> 0.5.3)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.3.1)
+      nap (~> 0.8)
+      xcodeproj (~> 0.26.3)
+    cocoapods-core (0.38.2)
+      activesupport (>= 3.2.15)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 0.8.0)
+    cocoapods-downloader (0.9.3)
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-stats (0.5.3)
+      nap (~> 0.8)
+    cocoapods-trunk (0.6.4)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (0.4.5)
+    colored (1.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.0)
+    molinillo (0.3.1)
+    nap (0.8.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.26.3)
+      activesupport (>= 3)
+      claide (~> 0.9.1)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (= 0.38.2)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -4,12 +4,26 @@ Native iOS app for [HabitRPG](https://habitrpg.com/).
 
 ## Setup for local development
 
-We are using [Cocoapods](http://cocoapods.org) to manage dependencies. So in order to set up the project, you have to install cocoapods first.
+We are using [Cocoapods](http://cocoapods.org) to manage dependencies.
 
-	sudo gem install cocoapods
+If you have managed ruby environment (rbenv, rvm, etc.):
 
-after that you can install the project dependencies.
+```
+$ bundle install
+$ bundle exec pod install
+```
 
-	pod install
-	
-Now you can open the *HabitRPG.xcworkspace* file and hopefully everything works. (Do not use the *.xcodeproj* file anymore.)
+If you require `sudo` to install gems (i.e. you are using the MacOS
+system ruby):
+
+```
+$ sudo gem install cocoapods
+$ pod install
+```
+
+CocoaPods requires that you open the *Habitica.xcworspace*.
+
+```
+$ open Habitica.xcworkspace
+```
+


### PR DESCRIPTION
### Motivation

I have multiple versions of CocoaPods installed on my machines.  Different projects require different versions of CocoaPods.  Running `pod install` will not work for me because I will never know what version of `pod` will be used.  This is especially problematic when testing beta versions of CocoaPods.

I added a Gemfile + lock that pins the version to 0.38.2 - the most recent released version.

To take advantage of the Gemfile + lock, use bundler.

```
$ bundle exec pod install
```

CocoaPods has a habit of introducing breaking/incompatible changes between versions.  Pinning to a specific version of CocoaPods is a good practice.  It is, after all, a dependency.

For most developers, adding a Gemfile + lock will be transparent.  If they don't run `bundle exec pod install`, the Gemfile + lock will be ignored.

When a new release of CocoaPods comes out, you can _update the dependency_ by changing the Gemfile and running:

```
$ bundle update
```

and committing the Gemfile and Gemfile.lock.

