### PR TITLE
Fix xcode framework search paths

### DIFF
--- a/Habitica.xcodeproj/project.pbxproj
+++ b/Habitica.xcodeproj/project.pbxproj
@@ -1456,7 +1456,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/HabitRPG",
 					"$(PROJECT_DIR)",
-					/Users/viirus/Downloads/Crashlytics.app/Contents/Resources,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HabitRPG/Habitica-Prefix.pch";
@@ -1539,7 +1538,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/HabitRPG",
 					"$(PROJECT_DIR)",
-					/Users/viirus/Downloads/Crashlytics.app/Contents/Resources,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HabitRPG/Habitica-Prefix.pch";

--- a/Habitica.xcodeproj/project.pbxproj
+++ b/Habitica.xcodeproj/project.pbxproj
@@ -1454,7 +1454,6 @@
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/HabitRPG",
 					"$(PROJECT_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1536,7 +1535,6 @@
 				EXCLUDED_SOURCE_FILE_NAMES = "FLEX*";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/HabitRPG",
 					"$(PROJECT_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
### Motivation

The Habitica build settings has two problems in the 'Framework Search Paths'.

* There was a reference to an absolute path _/Users/viirus_ resulting in:

`Directory not found for option -F/Users/viirus/Downloads/Crashlytics.app/Contents/Resources`

* The `$(PROJECT_DIR)/HabitRPG` has no frameworks and should not be searched.
