### PR TITLE
Protect Fabric API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .DS_Store
 *.log
 
+# Private API keys
+private/*.key
+
 # Created by https://www.gitignore.io
 ### Xcode ###
 build/

--- a/Habitica.xcodeproj/project.pbxproj
+++ b/Habitica.xcodeproj/project.pbxproj
@@ -1061,7 +1061,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Fabric.framework/run 2eb3b3edb3b0f4722d37d649a5af366656e46ddd d2ba51e7ded38c0a45cef17c3288994dc2f00032f3c076119f9fed034aeb154c";
+			shellScript = "bin/xcode-build-phase/fabric.sh";
 		};
 		E849E9FA1DD6461BA39AB99A /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/bin/xcode-build-phase/fabric.sh
+++ b/bin/xcode-build-phase/fabric.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Usage: Call from Xcode Build Phase
+#        bin/xcode-build-phase/fabric.sh
+#
+# Ask a maintainer for the Fabric API keys.
+#
+# See:
+#
+# * ./private/fabric.key.example
+
+FABRIC_KEY_FILE='./private/fabric.key'
+
+if [ -e "${FABRIC_KEY_FILE}" ]; then
+  source "${FABRIC_KEY_FILE}"
+  ./Fabric.framework/run ${FABRIC_API} ${FABRIC_API_SECRET}
+else
+  SCRIPT_PATH="./bin/xcode-build-phase/fabric.sh:14:"
+  REASON="File $FABRIC_KEY_FILE was not found."
+
+  if [ "${CONFIGURATION}" != "Release" ]; then
+    SKIPPING="warning: Skipping Fabric.framework/run"
+    echo "$SCRIPT_PATH $SKIPPING - $REASON"
+  else
+    FAILURE="error: Cannot execute Fabric.framework/run"
+    DETAILS="Fabric is required for Release configuration."
+    echo "$SCRIPT_PATH $FAILURE - $REASON $DETAILS"
+    exit 1
+  fi
+fi
+

--- a/private/fabric.key.example
+++ b/private/fabric.key.example
@@ -1,0 +1,14 @@
+# Install:
+#
+# 1. $ mkdir -p private
+# 2. $ mv private/fabric.key.example private/fabric.key
+# 3. Edit private/fabric.key with the correct keys.
+#
+# See:
+#
+# * https://docs.fabric.io/ios/fabric/migration/xcode.html
+# * bin/xcode-build-phase/fabric.sh
+
+FABRIC_API=<FABRIC API KEY>
+FABRIC_API_SECRET=<FABRIC API SECRET>
+


### PR DESCRIPTION
### Motivation

I noticed that the Fabric API keys were embedded in an Xcode Run Script build phase.

I _believe_ the API secret should be kept private.  I might be wrong.  All the projects that I work on that use Fabric are private, so I've never investigated this.

This is one strategy for keeping the API keys private.  Maybe there is something already in place?

I prefer script bodies to be outside of Xcode's Run Script Build Phase because:

1. To edit a Run Script, you have to touch the Xcode project file, which can lead to conflicts - especially in open source projects.
2. There is no syntax highlighting, indentation, or error highlighting in Xcode's Run Script text view.

I think the Fabric API secret should be changed now that it has been exposed.

I would be happy to add README.md instructions to this PR.

I will not be put out if this PR is rejected.  I am aware that this kind of change represents a change in process.