### PR TITLE
Fix unassigned assets, implicit and incompatible conversion warnings

### DIFF
--- a/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
+++ b/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
@@ -95,7 +95,7 @@ static NSString * const reuseIdentifier = @"Cell";
             setString = [setString stringByAppendingFormat:@"items.gear.owned.%@,", gear.key];
         }
     }
-    setString = [setString stringByPaddingToLength:setString.length-1 withString:nil startingAtIndex:0];
+    setString = [setString stringByPaddingToLength:setString.length-1 withString:@"" startingAtIndex:0];
     if (purchasable) {
         purchaseButton.hidden = false;
         [purchaseButton addTarget:self action:@selector(purchaseSet:) forControlEvents:UIControlEventTouchUpInside];

--- a/HabitRPG/GHFMarkdown_Private.m
+++ b/HabitRPG/GHFMarkdown_Private.m
@@ -26,7 +26,7 @@ NSString *const GHFMarkdownQuoteNewlinePadding = @"\n\n";
 NSString *GHFMarkdownMD5(NSString *string) {
     const char *cStr = [string UTF8String];
     unsigned char result[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(cStr, strlen(cStr), result);
+    CC_MD5(cStr, (CC_LONG)strlen(cStr), result);
     return [NSString stringWithFormat: @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
             result[0], result[1], result[2], result[3], result[4], result[5], result[6], result[7],
             result[8], result[9], result[10], result[11], result[12], result[13], result[14], result[15]];

--- a/HabitRPG/NSMutableAttributedString_GHFMarkdown.m
+++ b/HabitRPG/NSMutableAttributedString_GHFMarkdown.m
@@ -41,7 +41,7 @@
 - (void)ghf_applyAttributes:(NSDictionary *)attributes {
     NSRange range = NSMakeRange(0, self.length);
     [attributes enumerateKeysAndObjectsUsingBlock:^(id attributeKey, id attributeValues, BOOL *stop) {
-        [self enumerateAttribute:attributeKey inRange:range options:NULL usingBlock:^(id value, NSRange range, BOOL *stop) {
+        [self enumerateAttribute:attributeKey inRange:range options:kNilOptions usingBlock:^(id value, NSRange range, BOOL *stop) {
             if (value) [self addAttributes:attributeValues range:range];
         }];
     }];

--- a/HabitRPG/NSMutableString_GHFMarkdown.m
+++ b/HabitRPG/NSMutableString_GHFMarkdown.m
@@ -130,7 +130,7 @@
     NSMutableString *string = self;
     [codeBlocks enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         NSString *substitute = [NSString stringWithFormat:GHFMarkdownSubstitutionFormat, key];
-        [string replaceOccurrencesOfString:substitute withString:obj options:NULL range:NSMakeRange(0, string.length)];
+        [string replaceOccurrencesOfString:substitute withString:obj options:kNilOptions range:NSMakeRange(0, string.length)];
     }];
 }
 

--- a/HabitRPG/TableViewController/1Password.xcassets/onepassword-button.imageset/Contents.json
+++ b/HabitRPG/TableViewController/1Password.xcassets/onepassword-button.imageset/Contents.json
@@ -2,16 +2,17 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "onepassword-button.png"
+      "filename" : "onepassword-button.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "onepassword-button@2x.png"
+      "filename" : "onepassword-button@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
+      "filename" : "onepassword-button@3x.png",
       "scale" : "3x"
     }
   ],

--- a/HabitRPG/TableViewController/1Password.xcassets/onepassword-extension.imageset/Contents.json
+++ b/HabitRPG/TableViewController/1Password.xcassets/onepassword-extension.imageset/Contents.json
@@ -6,8 +6,8 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "onepassword-extension-iphone@2x.png"
+      "filename" : "onepassword-extension-iphone@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -20,13 +20,13 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "1x",
-      "filename" : "onepassword-extension-ipad.png"
+      "filename" : "onepassword-extension-ipad.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "onepassword-extension-ipad@2x.png"
+      "filename" : "onepassword-extension-ipad@2x.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/HabitRPG/TableViewController/1Password.xcassets/onepassword-navbar.imageset/Contents.json
+++ b/HabitRPG/TableViewController/1Password.xcassets/onepassword-navbar.imageset/Contents.json
@@ -2,16 +2,17 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "onepassword-navbar.png"
+      "filename" : "onepassword-navbar.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "onepassword-navbar@2x.png"
+      "filename" : "onepassword-navbar@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
+      "filename" : "onepassword-navbar@3x.png",
       "scale" : "3x"
     }
   ],

--- a/HabitRPG/TableViewController/1Password.xcassets/onepassword-toolbar.imageset/Contents.json
+++ b/HabitRPG/TableViewController/1Password.xcassets/onepassword-toolbar.imageset/Contents.json
@@ -2,16 +2,17 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "onepassword-toolbar.png"
+      "filename" : "onepassword-toolbar.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "onepassword-toolbar@2x.png"
+      "filename" : "onepassword-toolbar@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
+      "filename" : "onepassword-toolbar@3x.png",
       "scale" : "3x"
     }
   ],


### PR DESCRIPTION
There are more to solve. Also, a very useful Xcode project setting is "Treat warnings as errors" and isn't there without a reason.

I'm not accustomed with the code yet to fix all the warnings, but maybe some other people could fix them soon.
