### PR TITLE
Fix drawing issue with progress bar

### DIFF
--- a/HabitRPG/Views/HRPGProgressBar.m
+++ b/HabitRPG/Views/HRPGProgressBar.m
@@ -44,16 +44,17 @@
 
 - (void)drawRect:(CGRect)rect {
     CGContextRef context = UIGraphicsGetCurrentContext();
-    UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:8.0f];
-    CGContextSetFillColorWithColor(context, [[UIColor colorWithRed:0.8549 green:0.8549 blue:0.8549 alpha:1.0] CGColor]);
-    [path fill];
+    UIBezierPath *trackPath = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:8.0f];
+    CGContextSetFillColorWithColor(context, [[UIColor colorWithWhite:0.8549 alpha:1.0] CGColor]);
+    [trackPath fill];
     CGFloat percent = self.value / self.maxValue;
     if (self.maxValue == 0 || percent < 0) {
         percent = 0;
     }
-    path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(rect.origin.x, rect.origin.y, rect.size.width*percent, rect.size.height) cornerRadius:8.0f];
+    UIBezierPath *fillPath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(rect.origin.x, rect.origin.y, rect.size.width*percent, rect.size.height) cornerRadius:8.0f];
     CGContextSetFillColorWithColor(context, [self.barColor CGColor]);
-    [path fill];
+    [trackPath addClip];
+    [fillPath fill];
 }
 
 


### PR DESCRIPTION
Hello!

I am really glad you guys made a native iOS app, and open sourced, too! Massive kudos :clap: 
So, I hope I can help whenever I can with issues I find while using the app, so here is one:

The progress bar should probably clip the fill content, so it doesn't bleed outside the track. You can see below the images of the results before and after this PR

<img width="267" alt="screen shot 2015-12-07 at 11 49 56 pm" src="https://cloud.githubusercontent.com/assets/860511/11650420/e8644bdc-9d3d-11e5-9539-6fdf685fe33a.png">

<img width="263" alt="screen shot 2015-12-07 at 11 50 15 pm" src="https://cloud.githubusercontent.com/assets/860511/11650431/eda6877c-9d3d-11e5-8564-254a7b185729.png">
