### PR TITLE
Wall clock UILocalNotifications

### DIFF
--- a/HabitRPG/HRPGAppDelegate.m
+++ b/HabitRPG/HRPGAppDelegate.m
@@ -71,6 +71,7 @@
          localNotification.repeatInterval = NSDayCalendarUnit;
          localNotification.alertBody = NSLocalizedString(@"Remember to check off your Dailies!", nil);
          localNotification.soundName = UILocalNotificationDefaultSoundName;
+         localNotification.timeZone = [NSTimeZone defaultTimeZone];
          [[UIApplication sharedApplication] scheduleLocalNotification:localNotification];
     }
     

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -155,6 +155,7 @@ User *user;
     localNotification.repeatInterval = NSDayCalendarUnit;
     localNotification.alertBody = NSLocalizedString(@"Remember to check off your Dailies!", nil);
     localNotification.soundName = UILocalNotificationDefaultSoundName;
+    localNotification.timeZone = [NSTimeZone defaultTimeZone];
     [[UIApplication sharedApplication] scheduleLocalNotification:localNotification];
 }
 


### PR DESCRIPTION
Hello, it's `0998e86a-435a-4234-b1f4-c2388ed6b500`, again.

I am traveling these days, and noticed that habitica's notification fire date doesn't update automatically when my timezone changes. Ideally, the alert time specified should be interpreted as a "wall clock time", as in, irrelevant of the timezone. If set to 7 pm while in Boston, it should still alert at 7 pm when traveling to Tokyo.

This can be fixed easily by assigning the default timezone. I know, it's super counter-intuitive, but you can see `UILocalNotification` API reference, or [this stackoverflow post][sof] for more details.

[sof]: http://stackoverflow.com/questions/18424569/understanding-uilocalnotification-timezone