### PR TITLE
docs: update cocoapods version to be >= v1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '0.38.2'
+gem 'cocoapods', '>= 1.0.0.beta'
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you require `sudo` to install gems (i.e. you are using the MacOS
 system ruby):
 
 ```
-$ sudo gem install cocoapods
+$ sudo gem install cocoapods:'>=1.0.0.beta'
 $ pod install
 ```
 


### PR DESCRIPTION

my Habitica User-ID: 51102111-ed4a-4f13-972b-705a3c1e5808
`pod install` returns the following error:

    [!] Invalid `Podfile` file: undefined method `inherit!' for #<Pod::Podfile:0x007faa4c07efb0>. Updating CocoaPods might fix the issue.

`inherit! :search_paths` is a new feature added in [Cocoapods v1.0](http://blog.cocoapods.org/CocoaPods-1.0/)

Update Gemfile and README.md to use a currrently beta version of cocoapods version >= 1.0.0 to be compatible with Podfile setting.