### PR TITLE
chore: set debug.xcconfig to be used in Debug configurations

### DIFF
--- a/Habitica.xcodeproj/project.pbxproj
+++ b/Habitica.xcodeproj/project.pbxproj
@@ -1925,6 +1925,7 @@
 		};
 		D9EB4EC118CB4A9400BB2094 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A11A64FF1BAC9FC30037D41C /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";


### PR DESCRIPTION

my Habitica User-ID: 51102111-ed4a-4f13-972b-705a3c1e5808

Add `debug.xcconfig` to be used as Debug configuration in
Habitica Xcode project settings.

This solves the problem that `CUSTOM_DOMAIN` and `DISABLE_SSL`
variables are not being loaded in DEBUG mode.