### PR TITLE
style: add .clang-format initial draft

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle:  Google
+ColumnLimit:     100
+DerivePointerAlignment: false
+IndentWidth:     4
+ObjCBlockIndentWidth: 4
+PointerAlignment: Right
+...
+


### PR DESCRIPTION

my Habitica User-ID: 51102111-ed4a-4f13-972b-705a3c1e5808

Add [Clang-Format](http://clang.llvm.org/docs/ClangFormat.html) style configuration file to keep
code style consistent.

The following style guides can be used as references to
fine tune the [Clang-Format Style Options](http://clang.llvm.org/docs/ClangFormatStyleOptions.html).

- [WordPress](https://github.com/wordpress-mobile/objective-c-style-guide)
- [GitHub](https://github.com/github/objective-c-style-guide)
- [NYTimes](https://github.com/NYTimes/objective-c-style-guide)

To use the formatter with XCode, [ClangFormat-Xcode](https://github.com/travisjeffery/ClangFormat-Xcode/) or [BBUncrustifyPlugin-Xcode](https://github.com/benoitsan/BBUncrustifyPlugin-Xcode) 
XCode plugin can be installed.

[Uncrustify](https://github.com/uncrustify/uncrustify) style configuration can also be considered instead of Clang-Format.