### PR TITLE
add attributes to task creation if auto allocated

### DIFF
--- a/HabitRPG/HRPGManager.m
+++ b/HabitRPG/HRPGManager.m
@@ -604,6 +604,7 @@ NSString *currentUser;
                             inManagedObjectStore:managedObjectStore];
     [preferencesMapping addAttributeMappingsFromDictionary:@{
         @"@parent._id" : @"userID",
+        @"allocationMode" : @"allocationMode",
         @"dayStart" : @"dayStart",
         @"disableClasses" : @"disableClass",
         @"sleep" : @"sleep",

--- a/HabitRPG/HRPGModels/Preferences+CoreDataProperties.h
+++ b/HabitRPG/HRPGModels/Preferences+CoreDataProperties.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Preferences (CoreDataProperties)
 
+@property(nullable, nonatomic, retain) NSString *allocationMode;
 @property(nullable, nonatomic, retain) NSString *background;
 @property(nullable, nonatomic, retain) NSNumber *dayStart;
 @property(nullable, nonatomic, retain) NSNumber *disableClass;

--- a/HabitRPG/HabitRPG.xcdatamodeld/HabitRPG 23.xcdatamodel/contents
+++ b/HabitRPG/HabitRPG.xcdatamodeld/HabitRPG 23.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15D21" minimumToolsVersion="Xcode 4.3">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15B42" minimumToolsVersion="Xcode 4.3">
     <entity name="Armoire" parentEntity="MetaReward" syncable="YES"/>
     <entity name="BuyableItem" representedClassName="BuyableItem" isAbstract="YES" parentEntity="Item" syncable="YES">
         <attribute name="canBuy" optional="YES" attributeType="Boolean" syncable="YES"/>
@@ -147,6 +147,7 @@
     </entity>
     <entity name="Potion" representedClassName="Potion" parentEntity="MetaReward" syncable="YES"/>
     <entity name="Preferences" representedClassName="Preferences" syncable="YES">
+        <attribute name="allocationMode" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="background" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="dayStart" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="disableClass" optional="YES" attributeType="Boolean" syncable="YES"/>
@@ -357,7 +358,7 @@
         <element name="Outfit" positionX="0" positionY="0" width="128" height="225"/>
         <element name="Pet" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Potion" positionX="0" positionY="0" width="128" height="45"/>
-        <element name="Preferences" positionX="0" positionY="0" width="128" height="330"/>
+        <element name="Preferences" positionX="0" positionY="0" width="128" height="345"/>
         <element name="Quest" positionX="0" positionY="0" width="128" height="240"/>
         <element name="QuestCollect" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Reminder" positionX="0" positionY="0" width="128" height="105"/>

--- a/HabitRPG/cs.lproj/Localizable.strings
+++ b/HabitRPG/cs.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* No comment provided by engineer. */
 "As you complete real-world tasks, you now have a random chance of finding eggs and potions. Combine them to hatch pets" = "Při splnění úkolu v reálném životě máš možnost nalézt vejce a lektvary. Zkombinuj je a líhni mazlíčky";
 
+/* No comment provided by engineer. */
+"Attributes" = "Vlastnosti";
+
 /* Noun */
 "Authentication" = "Ověření";
 
@@ -480,6 +483,9 @@ Verze %1$@ (%2$@)";
 "Member Since" = "Členem od";
 
 /* No comment provided by engineer. */
+"Mental" = "Duševní";
+
+/* No comment provided by engineer. */
 "Menu" = "Menu";
 
 /* No comment provided by engineer. */
@@ -546,6 +552,9 @@ Verze %1$@ (%2$@)";
 "Organize Closet" = "Přerovnat skříň s oblečením";
 
 /* No comment provided by engineer. */
+"Other" = "Další";
+
+/* No comment provided by engineer. */
 "Participants" = "Účastníci";
 
 /* No comment provided by engineer. */
@@ -565,6 +574,9 @@ Verze %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "Pets" = "Mazlíčci";
+
+/* No comment provided by engineer. */
+"Physical" = "Fyzické";
 
 /* No comment provided by engineer. */
 "Positive (+)" = "Kladný (+)";
@@ -637,6 +649,9 @@ Verze %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "School" = "Škola";
+
+/* No comment provided by engineer. */
+"Select Attributes" = "Vybrat vlastnosti";
 
 /* No comment provided by engineer. */
 "Select Class" = "Vybrat povolání";

--- a/HabitRPG/da.lproj/Localizable.strings
+++ b/HabitRPG/da.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* No comment provided by engineer. */
 "As you complete real-world tasks, you now have a random chance of finding eggs and potions. Combine them to hatch pets" = "Når du udfører opgaver i den virkelige verden har du nu en chance for at finde æg og eliksirer. Kombinér dem for at udruge kæledyr";
 
+/* No comment provided by engineer. */
+"Attributes" = "Attributter";
+
 /* Noun */
 "Authentication" = "Godkendelse";
 
@@ -480,6 +483,9 @@ Version %1$@ (%2$@)";
 "Member Since" = "Medlem siden";
 
 /* No comment provided by engineer. */
+"Mental" = "Mental";
+
+/* No comment provided by engineer. */
 "Menu" = "Menu";
 
 /* No comment provided by engineer. */
@@ -546,6 +552,9 @@ Version %1$@ (%2$@)";
 "Organize Closet" = "Ryd op i skabet";
 
 /* No comment provided by engineer. */
+"Other" = "Andet";
+
+/* No comment provided by engineer. */
 "Participants" = "Deltagere";
 
 /* No comment provided by engineer. */
@@ -565,6 +574,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "Pets" = "Kæledyr";
+
+/* No comment provided by engineer. */
+"Physical" = "Fysisk";
 
 /* No comment provided by engineer. */
 "Positive (+)" = "Positiv (+)";
@@ -637,6 +649,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "School" = "Skole";
+
+/* No comment provided by engineer. */
+"Select Attributes" = "Vælg Attributter";
 
 /* No comment provided by engineer. */
 "Select Class" = "Vælg Klasse";

--- a/HabitRPG/de.lproj/Localizable.strings
+++ b/HabitRPG/de.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* No comment provided by engineer. */
 "As you complete real-world tasks, you now have a random chance of finding eggs and potions. Combine them to hatch pets" = "Während du echte Aufgaben bewältigst, hast du eine zufällige Möglichkeit Eier und Tränke zu finden. Kombiniere sie um Haustiere schlüpfen zu lassen";
 
+/* No comment provided by engineer. */
+"Attributes" = "Attribute";
+
 /* Noun */
 "Authentication" = "Authentifizierung";
 
@@ -480,6 +483,9 @@ Version %1$@ (%2$@)";
 "Member Since" = "Mitglied seit";
 
 /* No comment provided by engineer. */
+"Mental" = "Mental";
+
+/* No comment provided by engineer. */
 "Menu" = "Menü";
 
 /* No comment provided by engineer. */
@@ -546,6 +552,9 @@ Version %1$@ (%2$@)";
 "Organize Closet" = "Kleiderschrank sortieren";
 
 /* No comment provided by engineer. */
+"Other" = "Anderes";
+
+/* No comment provided by engineer. */
 "Participants" = "Teilnehmer";
 
 /* No comment provided by engineer. */
@@ -565,6 +574,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "Pets" = "Haustiere";
+
+/* No comment provided by engineer. */
+"Physical" = "Körperlich";
 
 /* No comment provided by engineer. */
 "Positive (+)" = "Positiv (+)";
@@ -637,6 +649,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "School" = "Schule";
+
+/* No comment provided by engineer. */
+"Select Attributes" = "Wähle Attribute aus";
 
 /* No comment provided by engineer. */
 "Select Class" = "Wähle Klasse aus";

--- a/HabitRPG/es.lproj/Localizable.strings
+++ b/HabitRPG/es.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* No comment provided by engineer. */
 "As you complete real-world tasks, you now have a random chance of finding eggs and potions. Combine them to hatch pets" = "Ahora, cuando realices tareas en el mundo real, puede que te toquen huevos y pociones. Combínalos para criar mascotas.";
 
+/* No comment provided by engineer. */
+"Attributes" = "Atributos";
+
 /* Noun */
 "Authentication" = "Autenticación";
 
@@ -480,6 +483,9 @@ Versión %1$@ (%2$@)";
 "Member Since" = "Miembro desde";
 
 /* No comment provided by engineer. */
+"Mental" = "Mentales";
+
+/* No comment provided by engineer. */
 "Menu" = "Menú";
 
 /* No comment provided by engineer. */
@@ -546,6 +552,9 @@ Versión %1$@ (%2$@)";
 "Organize Closet" = "Ordenar el armario";
 
 /* No comment provided by engineer. */
+"Other" = "Otro";
+
+/* No comment provided by engineer. */
 "Participants" = "Participantes";
 
 /* No comment provided by engineer. */
@@ -565,6 +574,9 @@ Versión %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "Pets" = "Mascotas";
+
+/* No comment provided by engineer. */
+"Physical" = "Físicos";
 
 /* No comment provided by engineer. */
 "Positive (+)" = "Positivo (+)";
@@ -637,6 +649,9 @@ Versión %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "School" = "Colegio";
+
+/* No comment provided by engineer. */
+"Select Attributes" = "Elegir atributos";
 
 /* No comment provided by engineer. */
 "Select Class" = "Elegir clase";

--- a/HabitRPG/zh.lproj/Localizable.strings
+++ b/HabitRPG/zh.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* No comment provided by engineer. */
 "As you complete real-world tasks, you now have a random chance of finding eggs and potions. Combine them to hatch pets" = "現在每當您完成現實世界的任務，都有機會獲得蛋和孵化靈藥。將兩者結合可孵育出寵物。";
 
+/* No comment provided by engineer. */
+"Attributes" = "属性";
+
 /* Noun */
 "Authentication" = "驗證";
 
@@ -480,6 +483,9 @@ Version %1$@ (%2$@)";
 "Member Since" = "加入時間";
 
 /* No comment provided by engineer. */
+"Mental" = "心理上的";
+
+/* No comment provided by engineer. */
 "Menu" = "選單";
 
 /* No comment provided by engineer. */
@@ -546,6 +552,9 @@ Version %1$@ (%2$@)";
 "Organize Closet" = "整理衣櫃";
 
 /* No comment provided by engineer. */
+"Other" = "其他";
+
+/* No comment provided by engineer. */
 "Participants" = "參與者";
 
 /* No comment provided by engineer. */
@@ -565,6 +574,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "Pets" = "寵物";
+
+/* No comment provided by engineer. */
+"Physical" = "生理上的";
 
 /* No comment provided by engineer. */
 "Positive (+)" = "正面的 ( + )";
@@ -637,6 +649,9 @@ Version %1$@ (%2$@)";
 
 /* No comment provided by engineer. */
 "School" = "學校";
+
+/* No comment provided by engineer. */
+"Select Attributes" = "選擇属性";
 
 /* No comment provided by engineer. */
 "Select Class" = "選擇職業";


### PR DESCRIPTION
This PR consists of one commit that adds a `XLFormRowDescriptor` for setting a task's attribute if task-based point allocation is set for the user. This is a feature is the iOS version of [#466](https://github.com/HabitRPG/habitrpg-android/pull/466).

It also includes the translations for the attributes and associated strings, taken from another Habitica repo with available translations.

My Habitica User-ID: 19095cf1-7620-4458-95cd-b4bd08fbe306