### PR TITLE
Add Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '>=1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,66 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    claide (1.0.0)
+    cocoapods (1.0.1)
+      activesupport (>= 4.0.2)
+      claide (>= 1.0.0, < 2.0)
+      cocoapods-core (= 1.0.1)
+      cocoapods-deintegrate (>= 1.0.0, < 2.0)
+      cocoapods-downloader (>= 1.0.0, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.0.0, < 2.0)
+      cocoapods-try (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      fourflusher (~> 0.3.0)
+      molinillo (~> 0.4.5)
+      nap (~> 1.0)
+      xcodeproj (>= 1.1.0, < 2.0)
+    cocoapods-core (1.0.1)
+      activesupport (>= 4.0.2)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.0)
+    cocoapods-downloader (1.0.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.0.0)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (1.0.0)
+    colored (1.2)
+    concurrent-ruby (1.0.2)
+    escape (0.0.4)
+    fourflusher (0.3.2)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    minitest (5.9.0)
+    molinillo (0.4.5)
+    nap (1.1.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (1.1.0)
+      activesupport (>= 3)
+      claide (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (>= 1.0)
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you require `sudo` to install gems (i.e. you are using the MacOS
 system ruby):
 
 ```
-$ sudo gem install cocoapods:'>=1.0.0.beta'
+$ sudo gem install cocoapods:'>=1.0'
 $ pod install
 ```
 


### PR DESCRIPTION
my Habitica User-ID: f03b56aa-2e49-4c0b-ae30-8df486be5f15

The README suggests that bundler is an acceptable way to manage Habitica's CocoaPods installation. The repo doesn't actually have a Gemfile, though, so running `bundle install` errors out. This fixes that!

(I also just bumped the README to reflect that CP 1.0 is now out of beta)

Thanks so much!