### PR TITLE
#390 - Enabling backgrounds to be unselected

### DIFF
--- a/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
+++ b/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
@@ -155,7 +155,7 @@ static NSString *const reuseIdentifier = @"Cell";
 
 - (void)collectionView:(UICollectionView *)collectionView
     didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
-    NSString *actionString = NSLocalizedString(@"Use", nil);
+    NSString *actionString = NSLocalizedString(@"Select", nil);
     NSInteger tag = 0;
     UIAlertController *alertController =  [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     [alertController addAction:[UIAlertAction cancelActionWithHandler:nil]];
@@ -173,8 +173,8 @@ static NSString *const reuseIdentifier = @"Cell";
             pinString = NSLocalizedString(@"Unpin from Rewards", nil);
         }
         
-        if ([self unselectingBackground: customization]) {
-            actionString = NSLocalizedString(@"Unselect", nil);
+        if ([self deselectBackground: customization]) {
+            actionString = NSLocalizedString(@"Deselect", nil);
         }
         
         path = [NSString stringWithFormat:@"backgrounds.%@.%@", customization.set, customization.name];
@@ -203,7 +203,7 @@ static NSString *const reuseIdentifier = @"Cell";
                                                               self.userKey : [self.selectedCustomization valueForKey:@"name"]
                                                               }
                                                   onSuccess:nil onError:nil];
-                    if ([self unselectingBackground: self.selectedCustomization]) {
+                    if ([self deselectBackground: self.selectedCustomization]) {
                         [[HRPGManager sharedManager] unlockPath:[self.selectedCustomization getPath]
                                                       onSuccess:nil onError:nil];
                     }
@@ -391,7 +391,7 @@ static NSString *const reuseIdentifier = @"Cell";
     [self presentViewController:navigationController animated:YES completion:nil];
 }
 
-- (BOOL) unselectingBackground:(Customization *)customization {
+- (BOOL) deselectBackground:(Customization *)customization {
     return [self.user.preferences.background isEqualToString:customization.name];
 }
 

--- a/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
+++ b/HabitRPG/CollectionViewController/HRPGCustomizationCollectionViewController.m
@@ -172,6 +172,11 @@ static NSString *const reuseIdentifier = @"Cell";
         if (self.pinnedItems[customization.name]) {
             pinString = NSLocalizedString(@"Unpin from Rewards", nil);
         }
+        
+        if ([self unselectingBackground: customization]) {
+            actionString = NSLocalizedString(@"Unselect", nil);
+        }
+        
         path = [NSString stringWithFormat:@"backgrounds.%@.%@", customization.set, customization.name];
         self.selectedCustomization = customization;
 
@@ -198,6 +203,11 @@ static NSString *const reuseIdentifier = @"Cell";
                                                               self.userKey : [self.selectedCustomization valueForKey:@"name"]
                                                               }
                                                   onSuccess:nil onError:nil];
+                    if ([self unselectingBackground: self.selectedCustomization]) {
+                        [[HRPGManager sharedManager] unlockPath:[self.selectedCustomization getPath]
+                                                      onSuccess:nil onError:nil];
+                    }
+                    
                 } else {
                     [[HRPGManager sharedManager] equipObject:[self.selectedCustomization valueForKey:@"key"]
                                                     withType:self.userKey
@@ -379,6 +389,10 @@ static NSString *const reuseIdentifier = @"Cell";
     UINavigationController *navigationController =
         [storyboard instantiateViewControllerWithIdentifier:@"PurchaseGemNavController"];
     [self presentViewController:navigationController animated:YES completion:nil];
+}
+
+- (BOOL) unselectingBackground:(Customization *)customization {
+    return [self.user.preferences.background isEqualToString:customization.name];
 }
 
 @end


### PR DESCRIPTION

my Habitica User-ID: 02ef7f10-b551-44fd-aa54-ee76dfb39f4a

I just added a option to unselect the background in case the user selected the same background before. I was in doubt if the best approach would be to include a new image (empty) so it's easier for the user to find the image. But since we don't have this image, I proceeded.

Another thing: I'm not sure if unselect is the correct word here. Maybe I should have used deselect ? (seems strange to me, but my native language isn't english )
