### PR TITLE
fix for #795, show toast for Guild and Party invites result

### DIFF
--- a/HabitRPG/Repositories/Implementations/SocialRepository.swift
+++ b/HabitRPG/Repositories/Implementations/SocialRepository.swift
@@ -333,10 +333,12 @@ class SocialRepository: BaseRepository<SocialLocalRepository> {
         let call = InviteToGroupCall(groupID: groupID, members: members)
         call.fire()
         call.habiticaResponseSignal.observeValues { (response) in
-            if let error = response?.message {
-                ToastManager.show(text: error, color: .red)
-            } else if response != nil {
-                ToastManager.show(text: L10n.usersInvited, color: .blue)
+            DispatchQueue.main.asyncAfter(wallDeadline: .now()+1) {
+                if let error = response?.message {
+                    ToastManager.show(text: error, color: .red)
+                } else if response != nil {
+                    ToastManager.show(text: L10n.usersInvited, color: .blue)
+                }
             }
         }
         return call.objectSignal

--- a/HabitRPG/UI/Social/InviteMembersViewController.swift
+++ b/HabitRPG/UI/Social/InviteMembersViewController.swift
@@ -91,6 +91,7 @@ class InviteMembersViewController: FormViewController {
                                             return TextRow { row in
                                                 row.cellSetup({ (cell, _) in
                                                     cell.tintColor = ThemeService.shared.theme.tintColor
+                                                    cell.textField.autocapitalizationType = .none
                                                 })
                                             }
                                         }
@@ -111,6 +112,8 @@ class InviteMembersViewController: FormViewController {
                                             return TextRow { row in
                                                 row.cellSetup({ (cell, _) in
                                                     cell.tintColor = ThemeService.shared.theme.tintColor
+                                                    cell.textField.keyboardType = .emailAddress
+                                                    cell.textField.autocapitalizationType = .none
                                                 })
                                             }
                                         }


### PR DESCRIPTION
Add delay before showing invitation result toast so it is not presented from a view controller that is being dismissed.

And set appropriate text input traits on Invite Members text fields as an enhancement.



my Habitica User-ID: 595736c5-32cc-42a0-bacf-b37838d82b8f