### PR TITLE
Fix title of Skill screen

### DIFF
--- a/HabitRPG/Generated/Strings-objcBridge.swift
+++ b/HabitRPG/Generated/Strings-objcBridge.swift
@@ -33,6 +33,7 @@ public class objcL10n: NSObject {
     @objc static let clear = L10n.clear
     @objc static let titleFeedPet = L10n.Titles.feedPet
     @objc static let titleShops = L10n.Titles.shops
+    @objc static let titleSkills = L10n.Titles.skills
     @objc static let titleSpells = L10n.Titles.spells
     @objc static let titleChooseRecipient = L10n.Titles.chooseRecipient
 

--- a/HabitRPG/TableViewController/Spells/HRPGSpellViewController.m
+++ b/HabitRPG/TableViewController/Spells/HRPGSpellViewController.m
@@ -19,7 +19,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.navigationItem.title = objcL10n.titleSpells;
+    self.navigationItem.title = objcL10n.titleSkills;    
     
     [self setupTableView];
     self.tutorialIdentifier = @"skills";


### PR DESCRIPTION
Fixes #796

### Changes
- Fix screen title (It was "Spells" instead of "Skills")
![Github](https://user-images.githubusercontent.com/46248839/56486292-d7a65e80-64df-11e9-9afa-479a22229bf8.png)

----
my Habitica User-ID: af1477b6-509a-4611-b851-d7a8e3a9c02a