### PR TITLE
[Issue 371] Converts HRPGLabeledProgressBar to use Auto Layout

### DIFF
--- a/HabitRPG/Views/HRPGLabeledProgressBar.m
+++ b/HabitRPG/Views/HRPGLabeledProgressBar.m
@@ -45,26 +45,77 @@
 
     self.color = [UIColor blackColor];
 
-    self.progressBar = [[ProgressBar alloc] init];
+    self.progressBar = [[ProgressBar alloc] initWithFrame:CGRectZero];
+    self.progressBar.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.progressBar];
-    self.iconView = [[UIImageView alloc] init];
-    self.iconView.contentMode = UIViewContentModeLeft;
+    
+    self.iconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+    self.iconView.translatesAutoresizingMaskIntoConstraints = NO;
     self.iconView.tintColor = [UIColor blackColor];
     [self addSubview:self.iconView];
-    self.labelView = [[UILabel alloc] init];
-    self.labelView.textAlignment = NSTextAlignmentLeft;
+    
+    self.labelView = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.labelView.translatesAutoresizingMaskIntoConstraints = NO;
     self.labelView.textColor = [UIColor darkGrayColor];
     [self addSubview:self.labelView];
-    self.typeView = [[UILabel alloc] init];
-    self.typeView.textAlignment = NSTextAlignmentRight;
-    self.typeView.textColor = [UIColor darkGrayColor];
+    
+    self.typeView = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.typeView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.typeView.textColor = [UIColor darkGrayColor ];
+    
     [self addSubview:self.typeView];
     self.fontSize = 11;
-    NSOperatingSystemVersion ios10_0_0 = (NSOperatingSystemVersion){10, 0, 0};
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:ios10_0_0]) {
+
+    if (@available(iOS 10.0, *)) {
         self.labelView.adjustsFontForContentSizeCategory = YES;
         self.typeView.adjustsFontForContentSizeCategory = YES;
     }
+    
+    UIUserInterfaceLayoutDirection direction = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute];
+    if (direction == UIUserInterfaceLayoutDirectionRightToLeft) {
+        self.progressBar.transform = CGAffineTransformMakeScale(-1.0, 1.0);
+    } else {
+        self.progressBar.transform = CGAffineTransformIdentity;
+    }
+    
+    [self setupConstraints];
+}
+
+-(void)setupConstraints {
+    
+    // iconView placement and size
+    [self.iconView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor].active = YES;
+    [self.iconView.widthAnchor constraintEqualToConstant:18.0].active = YES;
+    [self.iconView.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+    [self.iconView.heightAnchor constraintEqualToConstant:18.0].active = YES;
+    
+    // progressBar placement and size
+    [self.progressBar.leadingAnchor constraintEqualToAnchor:self.iconView.trailingAnchor constant:6.0].active = YES;
+    [self.progressBar.trailingAnchor constraintEqualToAnchor:self.trailingAnchor].active = YES;
+
+    [self.progressBar.heightAnchor constraintEqualToConstant:16.0].active = YES;
+    [self.progressBar.centerYAnchor constraintEqualToAnchor:self.iconView.centerYAnchor].active = YES;
+    
+    // label sizes will be intrinsic
+    
+    // labelView and typeView placement (horizontal):
+    [self.labelView.leadingAnchor constraintEqualToAnchor:self.progressBar.leadingAnchor constant:1.0].active = YES;
+    [self.labelView.trailingAnchor constraintGreaterThanOrEqualToAnchor:self.typeView.leadingAnchor constant:-4.0].active = YES;
+    [self.typeView.trailingAnchor constraintEqualToAnchor:self.progressBar.trailingAnchor constant:-1.0].active = YES;
+    
+    // Keep labelView to smallest possible size, this prevents need for alignment
+    [self.labelView setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [self.typeView setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+
+    // Favor showing all of the typeView label if combined is too big; this only kicks in if label is very long
+    [self.labelView setContentCompressionResistancePriority:751 forAxis:UILayoutConstraintAxisHorizontal];
+    
+    // Labels Placement (vertical)
+    
+    [self.labelView.topAnchor constraintEqualToAnchor:self.progressBar.bottomAnchor constant:2.0].active = YES;
+    [self.typeView.topAnchor constraintEqualToAnchor:self.progressBar.bottomAnchor constant:2.0].active = YES;
+    [self.labelView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
+    [self.typeView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
 }
 
 - (void)setColor:(UIColor *)color {
@@ -90,15 +141,9 @@
     self.progressBar.maxValue = [maxValue floatValue];
 }
 
-- (void)setFrame:(CGRect)frame {
-    [super setFrame:frame];
-    [self updateViewFrames];
-}
-
 - (void)setType:(NSString *)type {
     _type = type;
     self.typeView.text = self.type;
-    [self updateViewFrames];
     [self applyAccessibility];
 }
 
@@ -125,20 +170,11 @@
     _fontSize = (NSInteger) scaledFont.pointSize;
     self.typeView.font = scaledFont;
     self.labelView.font = scaledFont;
-    [self updateViewFrames];
-}
-- (void)updateViewFrames {
-    self.iconView.frame = CGRectMake(0, 0, 18, 18);
-    self.progressBar.frame = CGRectMake(24, 1, self.frame.size.width - 24, 16);
-    self.labelView.frame = CGRectMake(25, 19, (self.frame.size.width - 25) / 2, self.fontSize + 1);
-    self.typeView.frame = CGRectMake((self.frame.size.width + 25) / 2, 19,
-                                     (self.frame.size.width - 25) / 2, self.fontSize + 1);
 }
 
 - (void)layoutSubviews {
     [super layoutSubviews];
     [self.progressBar setNeedsDisplay];
-    [self updateViewFrames];
 }
 
 - (void)setIsActive:(BOOL)isActive {

--- a/Habitica.xcodeproj/xcshareddata/xcschemes/Habitica RTL.xcscheme
+++ b/Habitica.xcodeproj/xcshareddata/xcschemes/Habitica RTL.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
This solves the right-to-left text issue by switching the `HRPGLabeledProgressBar` class to use Auto Layout constraints with leading-to-trailing, deleting the frame-setting code. The ProgressBar is mirrored using a transform. While there is another pull request for this issue, I will comment on it there; I'm submitting this PR because it has a minimum changes necessary to support Auto Layout for right-to-left languages on this view.

About the mirrored Progress Bar: According to [Material Design's right-to-left discussion](https://material.io/design/usability/bidirectionality.html#mirroring-elements), the progress bar should be mirrored; that is done in this PR. However, it says numbers should not be, and this SO answer says [fractions specifically should not be mirrored](https://ux.stackexchange.com/questions/111783/fractions-x-out-of-y-complete-in-rtl-languages) in Arabic, so that label-setting code is unchanged. Alternative to setting transform here: the progressBar transform could be applied in the `ProgressBar` class (or the drawRect code altered, but that starts to add complexity in the wrong place) but since other places use the ProgressBar applying it here will ensure no other view is affected in other classes. 

There are also a few minor layout layout changes that resulted from the switch to Auto Layout: Horizontal: Positively, the labels each now use all available space between them. If not enough space, it will show all the experience and truncate the type. Vertical: Note there is a slight change in behavior, following Auto Layout defaults. If the view is vertically sized to be larger than needed, instead of white space left on the bottom, UIKit will pad the label, which will go on top and bottom. If the view is forced to use a size that is too-small vertically, it will clip the label internally. This could be changed but in the case of being force to use a size resulting in vertical clipping, not a lot can be done and the best solution would be to fix the containing layout that is forcing a too-small size. Looks fine on non-accessibility sizes. 

This pull request also makes minor fixes to changes the code that wraps `adjustsFontForContentSizeCategory` for version to the new Objc availability, and changes the RTL run scheme so that the run action doesn't require building the tests (caused an issue for me since the test target has different dependencies, there's no reason I'm aware of why the `run` action should build the test target). Other than that, this PR is as small as possible to switch to auto layout. 

my Habitica User-ID: d8953a01-6445-4837-bf91-380ec85ce1b7

