### PR TITLE
[#815] Enable class system if necessary before selecting

### DIFF
--- a/HabitRPG/UI/Settings/SettingsViewController.swift
+++ b/HabitRPG/UI/Settings/SettingsViewController.swift
@@ -719,8 +719,15 @@ class SettingsViewController: FormViewController, Themeable {
     }
     
     private func classSelectionButtonTapped() {
-        if user?.canChooseClassForFree == true {
-            showClassSelectionViewController()
+        guard let user = self.user else {
+            assertionFailure("Attempting to change class but there is no user!"); return
+        }
+        if user.canChooseClassForFree == true {
+            if user.needsToChooseClass {
+                showClassSelectionViewController()
+            } else {
+                enableClassSystemAndShowClassSelection()
+            }
         } else {
             let alertController = HabiticaAlertController(title: L10n.Settings.areYouSure, message: L10n.Settings.changeClassDisclaimer)
             alertController.addCancelAction()
@@ -728,6 +735,16 @@ class SettingsViewController: FormViewController, Themeable {
                 self?.showClassSelectionViewController()
             }
             alertController.show()
+        }
+    }
+    
+    private func enableClassSystemAndShowClassSelection() {
+        disposable.inner.add { [weak self] in
+            self?.userRepository.selectClass(nil)
+                .observe(on: UIScheduler())
+                .observeCompleted { [weak self] in
+                    self?.showClassSelectionViewController()
+            }
         }
     }
     


### PR DESCRIPTION
This is a fix for #815, enable class system before selecting. If the user can change class for free and classes are disabled, it will make a call to `User - Change Class` (https://habitica.com/apidoc/#api-User-UserChangeClass) -- the API docs are a little unclear but it seems like that is how you enable classes? If that's not the case let me know. 

After the call goes through, the user object should automatically update the table and refresh the text? (Again, not sure.) After the text is updated it would then go on to the class selection screen. 

This does not have any loading or error handling, which could be added but has design considerations. It also does not do anything for cell selection, which I'm not sure with the custom "form" for cell handling. Looks nice though, and it looks like it will automatically update.  

my Habitica User-ID: d8953a01-6445-4837-bf91-380ec85ce1b7

