### PR TITLE
Update iphone simulator version in the travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 script:
   - set -o pipefail
   - swiftlint --reporter "emoji"
-  - xcodebuild -workspace Habitica.xcworkspace -scheme HabiticaTests -destination "$DESTINATION" -sdk iphonesimulator12.1 clean build build-for-testing ONLY_ACTIVE_ARCH=NO | xcpretty  -f `xcpretty-travis-formatter`
-  - xcodebuild -workspace Habitica.xcworkspace -scheme HabiticaTests -destination "$DESTINATION" -sdk iphonesimulator12.1 test-without-building ONLY_ACTIVE_ARCH=NO | xcpretty  -f `xcpretty-travis-formatter`
+  - xcodebuild -workspace Habitica.xcworkspace -scheme HabiticaTests -destination "$DESTINATION" -sdk iphonesimulator12.2 clean build build-for-testing ONLY_ACTIVE_ARCH=NO | xcpretty  -f `xcpretty-travis-formatter`
+  - xcodebuild -workspace Habitica.xcworkspace -scheme HabiticaTests -destination "$DESTINATION" -sdk iphonesimulator12.2 test-without-building ONLY_ACTIVE_ARCH=NO | xcpretty  -f `xcpretty-travis-formatter`
 after_success:
   - sleep 10


### PR DESCRIPTION
Update the iPhone Simulator version from 12.1 to 12.2. The Xcode version was updated to 10.2 which does not contain the 12.1 simulator (see https://docs.travis-ci.com/user/reference/osx/). You can see the build successfully try to compile here: https://travis-ci.com/hjarrell/habitica-ios/jobs/241214639. The reason that it fails is that the Quick library needs to be updated to 1.3.3 which fixed this issue: https://github.com/Quick/Quick/issues/823. I didn't know if you guys wanted the version change in the same pull request or knew why it was failing.



my Habitica User-ID: 783e5ada-de36-4128-aee1-5ea033d93c20
