### PR TITLE
Remove username confirmation toast from setup

### DIFF
--- a/HabitRPG/Repositories/Implementations/UserRepository.swift
+++ b/HabitRPG/Repositories/Implementations/UserRepository.swift
@@ -247,7 +247,6 @@ class UserRepository: BaseRepository<UserLocalRepository> {
                     user.flags?.verifiedUsername = true
                 }
             }
-            ToastManager.show(text: L10n.usernameConfirmedToast, color: .green)
         })
     }
     


### PR DESCRIPTION
Removes the green confirmation toast for username.
Fixes #812 

**Before**
![Simulator Screen Shot - iPhone 11 - 2019-10-05 at 17 01 25](https://user-images.githubusercontent.com/5355231/66261435-bdf98a80-e792-11e9-96c4-5efc8b1bb571.png)

**After**
Hard to show that something doesn't exist/doesn't show but  🤷‍♀️.
![Simulator Screen Shot - iPhone 11 - 2019-10-05 at 17 06 47](https://user-images.githubusercontent.com/5355231/66261438-cbaf1000-e792-11e9-8a86-d83368e508ee.png)


my Habitica User-ID: 09229c96-d005-4f97-b9ca-d8a7d84718b3
