### PR TITLE
Use smaller font for guild crest text if necessary

### DIFF
--- a/HabitRPG/Utilities/HabiticaIcons.swift
+++ b/HabitRPG/Utilities/HabiticaIcons.swift
@@ -6549,8 +6549,16 @@ public class HabiticaIcons : NSObject {
         let labelRect = CGRect(x: 4, y: 20, width: 32, height: 13)
         let labelStyle = NSMutableParagraphStyle()
         labelStyle.alignment = .center
+
+        var font = UIFont(name: "HelveticaNeue", size: 12)!
+        
+        while font.pointSize > 0 && memberCountLabel.size(withAttributes: [
+            .font: font]).width > labelRect.width {
+                font = UIFont(name: "HelveticaNeue", size: font.pointSize - 1)!
+        }
+        
         let labelFontAttributes = [
-            .font: UIFont(name: "HelveticaNeue", size: 12)!,
+            .font: font,
             .foregroundColor: crestColor5,
             .paragraphStyle: labelStyle,
             ] as [NSAttributedString.Key: Any]


### PR DESCRIPTION

my Habitica User-ID: TheCodedSelf

Fixes #834 

Font size stays the same for all labels that could previously fit. Labels that wrap and clip (e.g. `110.1k`) are fixed by applying a reduced font size.

Screenshot of the result:

![Simulator Screen Shot - iPhone 11 - 2019-10-07 at 11 06 24](https://user-images.githubusercontent.com/10298140/66301433-6aed1800-e8f7-11e9-95e3-cfb00ed88c71.png)
