### PR TITLE
Fixes #820 - Filters: 'Clear' button doesn't completely reset filters.

### DIFF
--- a/HabitRPG/UI/Tasks/FilterViewController.swift
+++ b/HabitRPG/UI/Tasks/FilterViewController.swift
@@ -93,8 +93,13 @@ class FilterViewController: BaseTableViewController {
     }
     
     @IBAction func clearTags(_ sender: UIBarButtonItem) {
+	    resetFilterTypeControl()
         dataSource.clearTags()
     }
+
+	private func resetFilterTypeControl() {
+	    filterTypeControl.selectedSegmentIndex = 0
+	}
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         selectedTags = dataSource.selectedTagIds


### PR DESCRIPTION
Clear button resets only tags, but UISegmentedControl is a filter too. I've added a method to reset it as well.



my Habitica User-ID: Frostfeel
