### PR TITLE
[issue-859] Fixed Due date label for Dark Mode

### DIFF
--- a/HabitRPG/UI/Tasks/TaskFormViewController.swift
+++ b/HabitRPG/UI/Tasks/TaskFormViewController.swift
@@ -445,14 +445,16 @@ class TaskFormViewController: FormViewController, Themeable {
             <<< DateRow(TaskFormTags.dueDate) {[weak self] row in
                 row.title = L10n.Tasks.Form.dueDate
                 row.dateFormatter = self?.dateFormatter
-                row.cellSetup({ (cell, _) in
+                row.cellUpdate({ (cell, _) in
                     cell.tintColor = self?.lightTaskTintColor
                     cell.detailTextLabel?.textColor = self?.lightTaskTintColor
-                }).onCellSelection({ (_, row) in
+                    cell.textLabel?.textColor = ThemeService.shared.theme.primaryTextColor
+                }).onCellSelection({ (cell, row) in
                     if row.value == nil {
                         row.value = Date()
                         row.updateCell()
                     }
+                    cell.textLabel?.textColor = self?.lightTaskTintColor
                 })
             }
             <<< ButtonRow(TaskFormTags.dueDateClear) { row in


### PR DESCRIPTION
The `Due date` label under Scheduling(when creating or editing a To-Do) was not working properly on Dark Mode.

This PR fixes issue #859, as shown in the screenshots below:

### Light Mode
![HabiticaLightMode1](https://user-images.githubusercontent.com/6914354/69473411-fb41c800-0d92-11ea-9d68-b60fbe5322c9.png)

![HabiticaLightMode2](https://user-images.githubusercontent.com/6914354/69473413-00067c00-0d93-11ea-9520-e9430d1f3c4d.png)

### Dark Mode
![HabiticaDarkMode1](https://user-images.githubusercontent.com/6914354/69473419-0dbc0180-0d93-11ea-9ab7-fecb7a9018bc.png)

![HabiticaDarkMode2](https://user-images.githubusercontent.com/6914354/69473422-1280b580-0d93-11ea-8ea8-bf09f6515f3f.png)


my Habitica User-ID: 5455e189-f3b5-4b3e-9315-a11c4b082c29
