### PR TITLE
Disable Saturday and Sunday buttons for challeng tasks

### DIFF
--- a/HabitRPG/UI/Tasks/TaskFormRows/WeekdayFormCell.swift
+++ b/HabitRPG/UI/Tasks/TaskFormRows/WeekdayFormCell.swift
@@ -102,6 +102,7 @@ class WeekdayFormCell: Cell<WeekdaysValue>, CellType {
     
     @objc
     func saturdayTapped() {
+        if row.isDisabled { return }
         row.value?.saturday = !(row.value?.saturday ?? false)
         row.updateCell()
         if #available(iOS 10, *) {
@@ -111,8 +112,12 @@ class WeekdayFormCell: Cell<WeekdaysValue>, CellType {
     
     @objc
     func sundayTapped() {
+        if row.isDisabled { return }
         row.value?.sunday = !(row.value?.sunday ?? false)
         row.updateCell()
+        if #available(iOS 10, *) {
+            UISelectionFeedbackGenerator.oneShotSelectionChanged()
+        }
     }
    
     public override func update() {


### PR DESCRIPTION
I was looking at the code of WeekdayFormCell and noticed that some buttons lacked a condition to disable them on challenges.
Also, the Sunday button didn't have haptics feedback. 

This is off-topic, but I think using a guard statement here will be more "Swiftly".
___
Habitica User-ID: 2cedef5a-666a-484b-bd97-726209679923
