### PR TITLE
Get translate days from veryShortWeekdaySymbols

### DIFF
--- a/HabitRPG/UI/Tasks/TaskFormRows/WeekdayFormCell.swift
+++ b/HabitRPG/UI/Tasks/TaskFormRows/WeekdayFormCell.swift
@@ -48,6 +48,8 @@ class WeekdayFormCell: Cell<WeekdaysValue>, CellType {
         sundayLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(sundayTapped)))
         backgroundColor = .clear
         selectionStyle = .none
+
+        setupDayLabels()
     }
     
     @objc
@@ -121,6 +123,19 @@ class WeekdayFormCell: Cell<WeekdaysValue>, CellType {
             applyAccessibility()
         }
         contentView.backgroundColor = ThemeService.shared.theme.contentBackgroundColor.withAlphaComponent(0.8)
+    }
+
+    private func setupDayLabels() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: LanguageHandler.getAppLanguage().code)
+        let days = calendar.veryShortWeekdaySymbols
+        sundayLabel.text = days[0]
+        mondayLabel.text = days[1]
+        tuesdayLabel.text = days[2]
+        wednesdayLabel.text = days[3]
+        thursdayLabel.text = days[4]
+        fridayLabel.text = days[5]
+        saturdayLabel.text = days[6]
     }
     
     private func updateViews(taskRow: WeekdayRow, value: WeekdaysValue) {


### PR DESCRIPTION
#865 
Use `veryShortWeekdaySymbols` to get translated names.
I was not able to find documentation to be sure the order of the array returned is always the same, but from local testing, and from the code I found online ( [WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/5784c94caa27c5dd2fbee802be0f885105cabd60/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift#L184), [CalendarKit](https://github.com/richardtop/CalendarKit/blob/d645ec5dffcc3214fa8b5585e3e445033e0f2eeb/Source/Header/DaySymbolsView.swift#L43) ) it's safe to asume that is the case.
___
Habitica User-ID: 2cedef5a-666a-484b-bd97-726209679923
