### PR TITLE
Fix total count of pets & mounts

### DIFF
--- a/HabitRPG/TableViewDataSources/StableOverviewDataSource.swift
+++ b/HabitRPG/TableViewDataSources/StableOverviewDataSource.swift
@@ -71,9 +71,7 @@ class StableOverviewDataSource<ANIMAL: AnimalProtocol>: BaseReactiveCollectionVi
                     data[type]?.append(item)
                 }
             }
-            if animal.type != "premium" || isOwned {
-                item?.totalNumber += 1
-            }
+            item?.totalNumber += 1
             if isOwned {
                 item?.numberOwned += 1
             }


### PR DESCRIPTION
The Pet & Mounts page shows incorrect total counts for certain pets. In
particular, premium and non-owned pets show odd totals such as 0/0 if no
pets are owned or say 2/2 if only 2 pets are owned. The totals should
instead simply be accumulated normally without any conditions to show
something like 0/9 and 2/9, thus indicating how many pets are missing.

my Habitica User-ID: aec17a4c-e599-4d0b-b021-555e4df7ee11