### PR TITLE
Fix incorrect adventure guide background color on dark mode

### DIFF
--- a/HabitRPG/Storyboards/Base.lproj/Main.storyboard
+++ b/HabitRPG/Storyboards/Base.lproj/Main.storyboard
@@ -408,7 +408,6 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
-                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="trailing" secondItem="KXt-8h-VNr" secondAttribute="trailing" constant="12" id="4T7-du-Hll"/>
                                                             <constraint firstAttribute="height" priority="500" constant="22" id="DaW-Zd-kdM"/>
@@ -459,7 +458,6 @@
                                                 </constraints>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="wYP-zx-dbe" secondAttribute="trailing" constant="26" id="KLO-2j-deG"/>
                                             <constraint firstAttribute="height" priority="500" constant="500" id="OVm-hr-4FN"/>

--- a/HabitRPG/UI/User/AdventureGuideViewController.swift
+++ b/HabitRPG/UI/User/AdventureGuideViewController.swift
@@ -47,7 +47,7 @@ class AdventureGuideViewController: BaseUIViewController {
         super.applyTheme(theme: theme)
         view.backgroundColor = theme.contentBackgroundColor
         var textColor = UIColor.gray50
-        if (theme.isDark) {
+        if theme.isDark {
             textColor = theme.primaryTextColor
         }
         gettingStartedLabel.textColor = textColor


### PR DESCRIPTION
Before | After
--- | ---
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-04 at 19 19 52](https://user-images.githubusercontent.com/5748627/95020911-a17a8180-0676-11eb-9d74-633d5915521a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-04 at 18 52 51](https://user-images.githubusercontent.com/5748627/95020871-6ed08900-0676-11eb-9bd7-e408733fce3f.png)

my Habitica User-ID: 3712e6e7-6bc1-40f9-87e2-5e3bbdfdc7c1
