### PR TITLE
Fix logout crash after visiting the shop

### DIFF
--- a/HabitRPG/TableViewDataSources/ShopCollectionViewDataSource.swift
+++ b/HabitRPG/TableViewDataSources/ShopCollectionViewDataSource.swift
@@ -170,7 +170,10 @@ class ShopCollectionViewDataSource: BaseReactiveCollectionViewDataSource<InAppRe
             )
             .map({ (items, ownedGear) in
                 return items.filter({ (item) -> Bool in
-                    return !ownedGear.contains(item.key)
+                    guard item.isValid, let key = item.key else {
+                        return false
+                    }
+                    return !ownedGear.contains(key)
                 })
             })
             .on(value: {[weak self] items in

--- a/Habitica.xcodeproj/project.pbxproj
+++ b/Habitica.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		29FEB278202B491600EA245A /* Avatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FEB277202B491600EA245A /* Avatar.swift */; };
 		29FEB27A202B4F0400EA245A /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FEB279202B4F0400EA245A /* AvatarView.swift */; };
 		328C951E24A2C13100293E16 /* LinksOnlyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328C951D24A2C13100293E16 /* LinksOnlyTextView.swift */; };
+		32C71C6725507E65007E48C5 /* Habitica WidgetsExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 29BEE62B252CCFE100D456F8 /* Habitica WidgetsExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		49005B721F180589004830D9 /* HRPGCurrencyCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49005B711F180588004830D9 /* HRPGCurrencyCountView.swift */; };
 		49005B7C1F18371F004830D9 /* HRPGShopUserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49005B7B1F18371E004830D9 /* HRPGShopUserHeaderView.swift */; };
 		49005B7E1F183775004830D9 /* HRPGShopUserHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49005B7D1F183775004830D9 /* HRPGShopUserHeaderView.xib */; };
@@ -600,6 +601,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		32C71C6825507E65007E48C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D9EB4E8318CB4A9400BB2094 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 29BEE62A252CCFE100D456F8;
+			remoteInfo = "Habitica WidgetsExtension";
+		};
 		7A84E1A4228928AD0081E96F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D9EB4E8318CB4A9400BB2094 /* Project object */;
@@ -652,6 +660,7 @@
 			files = (
 				7A84E1A9228928AD0081E96F /* Habitica Intents.appex in Embed App Extensions */,
 				7A84E1A6228928AD0081E96F /* Habitica IntentsUI.appex in Embed App Extensions */,
+				32C71C6725507E65007E48C5 /* Habitica WidgetsExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2906,6 +2915,7 @@
 			dependencies = (
 				7A84E1A5228928AD0081E96F /* PBXTargetDependency */,
 				7A84E1A8228928AD0081E96F /* PBXTargetDependency */,
+				32C71C6925507E65007E48C5 /* PBXTargetDependency */,
 			);
 			name = Habitica;
 			productName = HabitRPG;
@@ -3962,6 +3972,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		32C71C6925507E65007E48C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 29BEE62A252CCFE100D456F8 /* Habitica WidgetsExtension */;
+			targetProxy = 32C71C6825507E65007E48C5 /* PBXContainerItemProxy */;
+		};
 		7A84E1A5228928AD0081E96F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;


### PR DESCRIPTION
Fixes #924 

This crash was caused by the unhandled exception `'RLMException', reason: 'Object has been deleted or invalidated.'`.
The problem was that after calling `localRepository.clearDatabase()`, an event was trigger on `ShopCollectionViewDataSource` containing invalid objects.

To fix it I added a guard statement, so the object properties are accessed only if the object is valid.

This branch also has an extra commit I needed to be able to install pods correctly, however if this change causes any problems, or for some reason is not needed, let me know and I will delete it.

my Habitica User-ID: `2cedef5a-666a-484b-bd97-726209679923`
