### PR TITLE
fix the mismatch of Chinese words

### DIFF
--- a/HabitRPG/Utilities/LanguageHandler.swift
+++ b/HabitRPG/Utilities/LanguageHandler.swift
@@ -40,13 +40,13 @@ enum AppLanguage: Int {
         case .czech:
             return "čeština"
         case .chinese:
-            return "中文（简体)"
+            return "中文（正體）"
         case .german:
             return "Deutsch"
         case .french:
             return "Français"
         case .chineseSimplified:
-            return "中文（正體)"
+            return "中文（简体）"
         case .portugueseBrazil:
             return "Português Brasileiro"
         case .hebrew:


### PR DESCRIPTION
replace right parenthesis with fullwidth one
Chinese Simplified = 中文（简体）

my Habitica User-ID: 72f5ab60-0a44-45a4-8afc-50003073160b
