### PR TITLE
End editing view after segmentControl changes

### DIFF
--- a/HabitRPG/UI/General/HabiticaSplitViewController.swift
+++ b/HabitRPG/UI/General/HabiticaSplitViewController.swift
@@ -105,11 +105,13 @@ class HabiticaSplitViewController: BaseUIViewController, UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let currentPage = getCurrentPage()
         segmentedControl.selectedSegmentIndex = currentPage
+        view.endEditing(true)
     }
     
     @objc
     func switchView(_ segmentedControl: UISegmentedControl) {
         scrollTo(page: segmentedControl.selectedSegmentIndex)
+        view.endEditing(true)
     }
     
     func getCurrentPage() -> Int {


### PR DESCRIPTION
Fixes #937

This was not only happening on the party chat, but instead it was a problem with all the subclasses of `HabiticaSplitViewController`.
With this simple fix, each time the segmentControl or the scrollView changes, the current view is force to end editing and hide the keyboard.

my Habitica User-ID: `2cedef5a-666a-484b-bd97-726209679923
`