### PR TITLE
Fix 'Wizard' text shown on market screen for mages

### DIFF
--- a/HabitRPG/TableViewDataSources/ShopCollectionViewDataSource.swift
+++ b/HabitRPG/TableViewDataSources/ShopCollectionViewDataSource.swift
@@ -96,7 +96,7 @@ class ShopCollectionViewDataSource: BaseReactiveCollectionViewDataSource<InAppRe
             let sectionCount = self?.sections.count ?? 0
             if sectionCount >= 2 {
                 self?.sections.removeLast(sectionCount - 1)
-            }            
+            }
             self?.loadCategories(shop?.categories ?? [], isSubscribed: user.isSubscribed)
             self?.delegate?.updateShopHeader(shop: shop)
             
@@ -228,12 +228,12 @@ class ShopCollectionViewDataSource: BaseReactiveCollectionViewDataSource<InAppRe
             headerView.otherClassDisclaimer.isHidden = true
             if indexPath.section == 0 && needsGearSection {
                 headerView.titleLabel.text = L10n.Equipment.classEquipment
-                headerView.gearCategoryLabel.text = selectedGearCategory?.capitalized
+                headerView.gearCategoryLabel.text = ifWizardConvertToMage(selectedGearCategory)?.capitalized
                 headerView.gearCategoryButton.isHidden = false
                 headerView.onGearCategoryLabelTapped = {[weak self] in
                     self?.delegate?.showGearSelection(sourceView: headerView.gearCategoryButton)
                 }
-                 headerView.otherClassDisclaimer.isHidden = userClass == selectedInternalGearCategory || selectedInternalGearCategory == "none"
+                headerView.otherClassDisclaimer.isHidden = userClass == selectedInternalGearCategory || selectedInternalGearCategory == "none"
                 headerView.otherClassDisclaimer.text = L10n.Shops.otherClassDisclaimer
             } else {
                 headerView.titleLabel.text = titleFor(section: indexPath.section)
@@ -243,6 +243,10 @@ class ShopCollectionViewDataSource: BaseReactiveCollectionViewDataSource<InAppRe
             return headerView
         }
         return UICollectionReusableView()
+    }
+
+    private func ifWizardConvertToMage(_ category: String?) -> String? {
+        return category == "wizard" ? "mage" : category
     }
    
     override func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {


### PR DESCRIPTION

my Habitica User-ID: `1de07bdd-8336-406d-92a3-1dbb03e78cbe`

Workaround that solves #1040 (for `Mages`, the initial label displayed on the drop-down list of the `Market` screen is `"Wizard"`). Ideally, later all old references to "wizards" should be refactored to use the new class name.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/39912609/128221632-0580cc7b-82da-47d8-a50f-0d389f10338c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/39912609/128221628-f565611d-529f-4545-95c6-e2dfcf5a3892.png" width="300" /> |

