### PR TITLE
Fix cut off answer in FAQ detail screen

### DIFF
--- a/HabitRPG/Storyboards/Base.lproj/Support.storyboard
+++ b/HabitRPG/Storyboards/Base.lproj/Support.storyboard
@@ -497,11 +497,8 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" contentInsetAdjustmentBehavior="never" editable="NO" text="werqwerqwer" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="U5U-nR-j47" customClass="MarkdownTextView" customModule="Habitica" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="55.5" width="414" height="500"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="36.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="500" id="qKJ-JZ-Bi8"/>
-                                        </constraints>
                                         <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>


### PR DESCRIPTION
my Habitica User-ID: `1de07bdd-8336-406d-92a3-1dbb03e78cbe`

Fix issue #1049. 

Due to a superfluous height constraint for the `Answer Text View` in the `Support.storyboard`, the text of longer FAQ answers would be cut off and it would be impossible to scroll down: now the aforementioned view is properly constrained utilizing the whole expected safe area space and vertical scrolling works normally.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/39912609/130328778-74d485d5-c44f-4538-b09d-cc959e267382.png" width="300" /> | <img src="https://user-images.githubusercontent.com/39912609/130328785-a3bfdeab-fd0a-4a1b-a082-20225e46d6ce.png" width="300" /> |


