### PR TITLE
Fix ToastView glitchy display on dark mode

### DIFF
--- a/HabitRPG/Views/ToastView.xib
+++ b/HabitRPG/Views/ToastView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -35,10 +33,10 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="NPK-t4-F2f" customClass="RoundedView" customModule="Habitica" customModuleProvider="target">
+                <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="NPK-t4-F2f" customClass="RoundedView" customModule="Habitica" customModuleProvider="target">
                     <rect key="frame" x="144.5" y="553" width="86" height="54"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GNY-gD-41u">
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GNY-gD-41u">
                             <rect key="frame" x="0.0" y="4" width="46" height="46"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>


### PR DESCRIPTION
my Habitica User-ID: `1de07bdd-8336-406d-92a3-1dbb03e78cbe`

Fix issue #1051. 

The primary [UIView](https://developer.apple.com/documentation/uikit/uiview) of `ToastView.xib` is lacking the [clipsToBounds](https://developer.apple.com/documentation/uikit/uiview/1622415-clipstobounds) property, which causes the white background of a subview to overflow beyond its parent's rounded bounds, resulting in a glitchy display on dark mode.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/39912609/130337674-5661a799-b9dd-480c-8b17-96630dc2d0a7.png" width="300" /> | <img src="https://user-images.githubusercontent.com/39912609/130337678-1d1697ce-411f-4601-995e-b9dd9b403546.png" width="300" /> |