### PR TITLE
Hide empty search bar

### DIFF
--- a/HabitRPG/TableViewController/Tasks/TaskTableViewController.swift
+++ b/HabitRPG/TableViewController/Tasks/TaskTableViewController.swift
@@ -315,7 +315,15 @@ class TaskTableViewController: BaseTableViewController, UISearchBarDelegate, UIT
     }
     
     // MARK: - Search
-    
+
+    private func hideSearchBar() {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.searchBar.alpha = 0
+        }, completion: { _ in
+            self.searchBar.removeFromSuperview()
+        })
+    }
+
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         searchBar.setShowsCancelButton(true, animated: true)
     }
@@ -340,11 +348,7 @@ class TaskTableViewController: BaseTableViewController, UISearchBarDelegate, UIT
         searchBar.setShowsCancelButton(false, animated: true)
         
         HRPGSearchDataManager.shared().searchString = nil
-        UIView.animate(withDuration: 0.3, animations: {
-            self.searchBar.alpha = 0
-        }) { _ in
-            self.searchBar.removeFromSuperview()
-        }
+        hideSearchBar()
         tableView.reloadData()
     }
     

--- a/HabitRPG/TableViewController/Tasks/TaskTableViewController.swift
+++ b/HabitRPG/TableViewController/Tasks/TaskTableViewController.swift
@@ -186,6 +186,9 @@ class TaskTableViewController: BaseTableViewController, UISearchBarDelegate, UIT
     override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         searchBar.resignFirstResponder()
         searchBar.setShowsCancelButton(false, animated: true)
+        if searchBar.text?.isEmpty == true {
+            hideSearchBar()
+        }
     }
     
     @IBAction func unwindFilterChanged(segue: UIStoryboardSegue?) {


### PR DESCRIPTION
Closes #1083.

As mentioned, this PR hides the search bar when the keyboard is dismissed and the search text is empty.

---

Habitica User-ID: 2cedef5a-666a-484b-bd97-726209679923
