### PR TITLE
Makes next checkin more accurate

### DIFF
--- a/HabitRPG/Generated/Strings.swift
+++ b/HabitRPG/Generated/Strings.swift
@@ -619,8 +619,8 @@ public enum L10n {
     return L10n.tr("Mainstrings", "next_checkin_prize_x_days", p1)
   }
   /// Next prize in %d Check-Ins
-  public static func nextPrizeInXCheckins(_ p1: Int) -> String {
-    return L10n.tr("Mainstrings", "next_prize_in_x_checkins", p1)
+  public static func nextPrizeAtXCheckins(_ p1: Int) -> String {
+    return L10n.tr("Mainstrings", "next_prize_at_x_checkins", p1)
   }
   /// No Benefit
   public static var noBenefit: String { return L10n.tr("Mainstrings", "no_benefit") }

--- a/HabitRPG/Strings/Base.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/Base.lproj/Mainstrings.strings
@@ -847,7 +847,7 @@
 "earned_achievement_share" = "I earned a new achievement in Habitica!";
 "next_checkin_prize_1_day" = "Your next prize unlocks in 1 Check-In.";
 "next_checkin_prize_x_days" = "Your next prize unlocks in %d Check-Ins";
-"next_prize_in_x_checkins" = "Next prize in %d Check-Ins";
+"next_prize_at_x_checkins" = "Next prize at %d Check-Ins";
 "checkin_prize_earned" = "You earned a %s as a reward for your devotion to improving your life.";
 "recipient" = "Recipient";
 "invalid_recipient_message" = "You have to specify a valid Habitica Username as recipient.";

--- a/HabitRPG/Utilities/NotificationManager.swift
+++ b/HabitRPG/Utilities/NotificationManager.swift
@@ -171,7 +171,7 @@ class NotificationManager {
                                          message: nil)
             let mutableString = NSMutableAttributedString(string: L10n.checkinPrizeEarned(loginIncentiveNotification.rewardText ?? ""))
             mutableString.append(NSAttributedString(string: "\n\n"))
-            mutableString.append(NSAttributedString(string: L10n.nextPrizeInXCheckins(nextRewardAt), attributes: [
+            mutableString.append(NSAttributedString(string: L10n.nextPrizeAtXCheckins(nextRewardAt), attributes: [
                 .font: UIFont.systemFont(ofSize: 14, weight: .semibold)
             ]))
             alert.attributedMessage = mutableString


### PR DESCRIPTION
This addresses #1086 

# Changes
- Changed localized string retrieve method name from `nextPrizeInXCheckins` to `nextPrizeAtXCheckins`
- Adjusted reward message to accurately show **AT** what number of checkins the next prize will be, instead of **IN** how many checkins the next prize will be.

# Description

I ended up not calculating the number of check-ins until the next prize. This is because the parameter for the number of checkins in the`nextPrizeAtXCheckins` method (previously `nextPrizeInXCheckins`) is generated from the "content" json fixture, under the key: `loginIncentives`. When a login incentive notification is generated, the nextRewardAt property is assigned and we do not have access to the current number of checkins. 

A fix for this would involve manually adding a nextRewardIn key to all of the different checkins in the json file, under `loginIncentives`. Then, consequently, one would have to add a nextRewardIn variable to the `NotificationLoginIncentive` protocol and the `APILoginIncentiveData` class. 

# More Info

Here is some useful info I discovered to hopefully point anyone looking to solve this in the right direction:

When Habitica API Client produces a response for a notification, the HabiticaResponse class attempts to decode the response into an array of APINotifications. If the type of a notification is a login incentive the data is decoded using the APILoginIncentiveData class, which maps directly to the NotificationLoginIncentiveProtocol, inside `APINotification.swift`. 

From here the habiticaResponseSignal passes the responses's notification parameter to an AuthenticatedCall's notificationListener, which is defined in an AppDelegate function called `setupNetworkClient()`. The notifications are passed to the NotificationManager class which displays each notification based on their type. 

---

my Habitica User-ID: 7e826b3d-b8d1-41ea-9bcb-6f6d148ace6f
