### PR TITLE
Fix ordered lists markdown, issue #990

### DIFF
--- a/HabitRPG/Extensions/Down-Extensions.swift
+++ b/HabitRPG/Extensions/Down-Extensions.swift
@@ -27,7 +27,7 @@ extension Down {
                                     textColor: UIColor = ThemeService.shared.theme.primaryTextColor, useAST: Bool = true, highlightUsernames: Bool = true) throws -> NSMutableAttributedString {
         let mentions = matchUsernames(text: markdownString)
         
-        if markdownString.range(of: "[*_#\\[<>`]", options: .regularExpression, range: nil, locale: nil) == nil {
+        if markdownString.range(of: "[*_#\\[<>`]|\\A\\d+[\\.\\)]", options: .regularExpression, range: nil, locale: nil) == nil {
             let string = NSMutableAttributedString(string: markdownString,
                                                    attributes: [.font: CustomFontMetrics.scaledSystemFont(ofSize: baseSize),
                                                                 .foregroundColor: textColor])
@@ -203,10 +203,20 @@ private class HabiticaStyler: DownStyler {
         paragraphStyle.paragraphSpacing = 7
         str.addAttribute(.paragraphStyle, value: paragraphStyle)
     }
+    
     override func style(listItemPrefix str: NSMutableAttributedString) {
         str.addAttribute(.font, value: CustomFontMetrics.scaledSystemFont(ofSize: baseSize))
         str.addAttribute(.foregroundColor, value: textColor)
-        str.replaceCharacters(in: NSRange(location: 1, length: 1), with: " ")
+        
+        var listDotLocation = 0
+
+        for char in str.string {
+            if Int(String(char)) == nil {
+                break
+            }
+            listDotLocation += 1
+        }
+        str.replaceCharacters(in: NSRange(location: listDotLocation, length: 1), with: " ")
     }
 
     override func style(text str: NSMutableAttributedString) {


### PR DESCRIPTION
This work is related to issue #990

First of all, needed to match an ordered list item with Regex at Line 30 in Down-Extensions.

The regex`\\A\\d+[\\.\\)]` (escaped version of `\A\d+[\.\)]`) catches `\A`: beginning of string, `\d+`: one or more digits,` [\.|\)]`: either one dot "." or one round bracket ")". Examples:

"1."
"2)"
"12."
"30)"

To style the ordered list, I changed the style(listItemPrefix at line 107. Before it was just considering one-digit numbers and replacing the character after it. So "1." would become "1 ".

The logic I followed was to start at the beginning of the string and see where the string stops being a number, thus being either "." or ")".

---

my Habitica User-ID: ccf1ce82-1e91-4dd1-9b17-aa4fc4c4f2f2
