### PR TITLE
Fix crash in 'every X days' string due to localization issues - Issue #1097

### DIFF
--- a/HabitRPG/Strings/de.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/de.lproj/Mainstrings.strings
@@ -894,7 +894,7 @@
 "username_prompt_wiki" = "Wenn Du mehr über diese Änderung wissen möchtest, #<wk>besuche unser Wiki.#";
 "buy_reward" = "Du hast '%@' für %@ Gold gekauft";
 "tasks.due_x" = "Fällig %@";
-"tasks.every_x" = "jeden %@";
+"tasks.every_x" = "jeden %d %@";
 "tasks.repeats.repeats_every_on" = "Wiederholt %@ am %@";
 "tasks.repeats.repeats_every" = "Wiederholt %@";
 "tasks.examples.team_habit" = "Checke mit dem Team ein";

--- a/HabitRPG/Strings/es.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/es.lproj/Mainstrings.strings
@@ -858,7 +858,7 @@
 "tasks.due_tomorrow" = "Vence mañana";
 "tasks.due_in_x_days" = "Vence en %d días";
 "tasks.due_x" = "Vence %@";
-"tasks.every_x" = "cada %@";
+"tasks.every_x" = "cada %d %@";
 "tasks.repeats.repeats_every_on" = "Se repite %@ de %@";
 "tasks.repeats.repeats_every" = "Se repite %@";
 "tasks.repeats.monthly_the" = "El %@";

--- a/HabitRPG/Strings/fr.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/fr.lproj/Mainstrings.strings
@@ -811,7 +811,7 @@
 "tasks.due_tomorrow" = "Échéance demain";
 "tasks.due_in_x_days" = "Échéance dans %d jours";
 "tasks.due_x" = "Échéance %@";
-"tasks.every_x" = "chaque %@";
+"tasks.every_x" = "chaque %d %@";
 "tasks.repeats.repeats_every_on" = "Se répète %@ le %@";
 "tasks.repeats.repeats_every" = "Se répète %@";
 "tasks.repeats.monthly_the" = "le %@";

--- a/HabitRPG/Strings/he.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/he.lproj/Mainstrings.strings
@@ -497,7 +497,7 @@
 "tasks.due_tomorrow" = "מסתיימים מחר";
 "tasks.due_in_x_days" = "מסתיימים ב%d ימים";
 "tasks.due_x" = "מסתיימים ב %@";
-"tasks.every_x" = "כל %@";
+"tasks.every_x" = "כל %d %@";
 "tasks.repeats.repeats_every_on" = "חזור על %@ ב %@";
 "tasks.repeats.repeats_every" = "חוזר שוב  %@";
 "tasks.repeats.daily" = "יום יומי";

--- a/HabitRPG/Strings/it.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/it.lproj/Mainstrings.strings
@@ -775,7 +775,7 @@
 "tasks.due_tomorrow" = "Scade domani";
 "tasks.due_in_x_days" = "Scade tra %d giorni";
 "tasks.due_x" = "Scade %@";
-"tasks.every_x" = "ogni %@";
+"tasks.every_x" = "ogni %d %@";
 "titles.avatar" = "Avatar";
 "tasks.examples.team_todo_text" = "Completa il progetto della squadra";
 "settings.app_icon" = "Icona dell'App";

--- a/HabitRPG/Strings/ja.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/ja.lproj/Mainstrings.strings
@@ -808,7 +808,7 @@
 "tasks.due_tomorrow" = "期限　明日";
 "tasks.due_in_x_days" = "期限　%d日後";
 "tasks.due_x" = "期限　%@";
-"tasks.every_x" = "毎%@";
+"tasks.every_x" = "毎 %d %@";
 "tasks.repeats.repeats_every_on" = "%@を%@ごとにくり返す";
 "tasks.repeats.repeats_every" = "%@くり返す";
 "tasks.repeats.monthly_the" = "%@";

--- a/HabitRPG/Strings/pt-BR.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/pt-BR.lproj/Mainstrings.strings
@@ -858,7 +858,7 @@
 "tasks.due_tomorrow" = "Amanha";
 "tasks.due_in_x_days" = "Prazo em %d dias";
 "tasks.due_x" = "Vencimento %@";
-"tasks.every_x" = "cada %@";
+"tasks.every_x" = "cada %d %@";
 "tasks.repeats.repeats_every_on" = "Repete %@ em %@";
 "tasks.repeats.repeats_every" = "Repete %@";
 "tasks.repeats.monthly_the" = "a %@";

--- a/HabitRPG/Strings/ro.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/ro.lproj/Mainstrings.strings
@@ -865,7 +865,7 @@
 "tasks.due_tomorrow" = "Termen limită mâine";
 "tasks.due_in_x_days" = "Termen limită în %@ zile";
 "tasks.due_x" = "Termen limită %@";
-"tasks.every_x" = "la fiecare %@";
+"tasks.every_x" = "la fiecare %d %@";
 "tasks.repeats.repeats_every_on" = "Se repetă din %@ în %@";
 "tasks.repeats.repeats_every" = "Se repetă %@";
 "tasks.repeats.monthly_the" = "%@ul\n%@a";

--- a/HabitRPG/Strings/ru.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/ru.lproj/Mainstrings.strings
@@ -839,7 +839,7 @@
 "tasks.team" = "Команда";
 "tasks.due_today" = "Истекает сегодня";
 "tasks.due_in_x_days" = "Через %d день";
-"tasks.every_x" = "каждый %@";
+"tasks.every_x" = "каждый %d %@";
 "tasks.repeats.repeats_every_on" = "Повторять %@ по %@";
 "tasks.repeats.repeats_every" = "Повторять %@";
 "tasks.repeats.monthly_the" = "%@";

--- a/HabitRPG/Strings/zh-Hans.lproj/Mainstrings.strings
+++ b/HabitRPG/Strings/zh-Hans.lproj/Mainstrings.strings
@@ -384,7 +384,7 @@
 "tasks.due_tomorrow" = "明天到期";
 "tasks.due_in_x_days" = "%d天后到期";
 "tasks.due_x" = "%@ 到期";
-"tasks.every_x" = "每 %@";
+"tasks.every_x" = "每 %d %@";
 "tasks.repeats.repeats_every_on" = "重复 %@ 在 %@";
 "tasks.repeats.repeats_every" = "%@ 重复";
 "tasks.repeats.daily" = "每日";


### PR DESCRIPTION
This is related to issue #1097 .

The localization of the text "Repeats every %d %@" (For example, "Repeat every 3 days") was crashing the app

The problem seems to be in some localizations (Italian, Spanish, Portuguese, etc.) that were not using both variables passed (%d: frequency for repetition, %@: unit of time [such as day]), and this caused some problem with memory, apparently.

What I did to fix this crash was to add the missing %d in the localization strings.

---

my Habitica User-ID:  ccf1ce82-1e91-4dd1-9b17-aa4fc4c4f2f2
