### PR TITLE
Fix task list for spell target's background color

### DIFF
--- a/HabitRPG/UI/Skills/SkillsTaskTableViewController.swift
+++ b/HabitRPG/UI/Skills/SkillsTaskTableViewController.swift
@@ -24,6 +24,7 @@ class SkillsTaskTableViewController: UITableViewController {
     }
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureTableViewBackgroundColor()
         
         if let taskType = self.taskType {
             dataSource = SkillsTaskTableViewDataSource(taskType: taskType)
@@ -38,4 +39,9 @@ class SkillsTaskTableViewController: UITableViewController {
             tabBarController?.castSpell()
         }
     }
+
+    private func configureTableViewBackgroundColor() {
+        self.tableView.backgroundColor = ThemeService.shared.theme.contentBackgroundColor
+    }
+
 }


### PR DESCRIPTION
my Habitica User-ID: `1de07bdd-8336-406d-92a3-1dbb03e78cbe`

Fix issue #1105. 

Set `SkillsTaskTableViewController`'s [UITableView](https://developer.apple.com/documentation/uikit/uitableview)'s background color according to the theme mode.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/39912609/138496265-f2f8b91c-02a8-418b-9dc1-2e21be819724.png" width="300" /> | <img src="https://user-images.githubusercontent.com/39912609/138496301-29113fbb-79ce-4b11-8b20-7f4217afa772.png" width="300" /> |