### PR TITLE
Hide FB button on register screen and resize stack view appropriately - Issue #1084

### DIFF
--- a/HabitRPG/Storyboards/Base.lproj/Intro.storyboard
+++ b/HabitRPG/Storyboards/Base.lproj/Intro.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="upQ-EI-E3w">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="upQ-EI-E3w">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -386,6 +386,7 @@
                         <outlet property="passwordRepeatField" destination="U2x-qx-w87" id="1Vy-ry-F6M"/>
                         <outlet property="privacyPolicyLabel" destination="E6t-4E-ZNY" id="Mk6-AI-XL5"/>
                         <outlet property="registerBeginButton" destination="Ohf-iu-Phe" id="POZ-1N-6gG"/>
+                        <outlet property="socialLoginStackView" destination="Jr8-6m-ty0" id="UOK-Dg-mw9"/>
                         <outlet property="usernameField" destination="u44-DM-dLI" id="qp1-8m-KY5"/>
                         <segue destination="qul-kf-4Gi" kind="presentation" identifier="MainSegue" customClass="MainVCSelectionSegue" customModule="Habitica" customModuleProvider="target" modalPresentationStyle="fullScreen" modalTransitionStyle="crossDissolve" id="aKA-6e-Im9"/>
                         <segue destination="v9W-i7-og5" kind="presentation" identifier="SetupSegue" modalPresentationStyle="fullScreen" id="5Hb-dX-OsZ"/>
@@ -1270,7 +1271,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="5Hb-dX-OsZ"/>
-        <segue reference="Z2J-RM-J8b"/>
+        <segue reference="aKA-6e-Im9"/>
         <segue reference="TYz-5x-Fui"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/HabitRPG/UI/Login/LoginTableViewController.swift
+++ b/HabitRPG/UI/Login/LoginTableViewController.swift
@@ -36,12 +36,15 @@ class LoginTableViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var logoHeight: NSLayoutConstraint!
     @IBOutlet weak var forgotPasswordButton: UIButton!
     @IBOutlet weak var privacyPolicyLabel: UITextView!
+    @IBOutlet weak var socialLoginStackView: UIStackView!
     
     @IBOutlet weak var logoView: UIImageView!
     @IBOutlet weak private var loginActivityIndicator: UIActivityIndicatorView!
 
     private let viewModel = LoginViewModel()
     private let userRepository = UserRepository()
+    
+    private var socialLoginStackViewWidthConstraint: NSLayoutConstraint!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -238,9 +241,23 @@ class LoginTableViewController: UIViewController, UITextFieldDelegate {
             if value {
                 weakSelf.emailField.isHidden = false
                 weakSelf.emailField.entryView.isEnabled = true
+                // Hide Facebook button on Register screen
+                weakSelf.facebookLoginButton.isHidden = true
+                if let socialLoginStackViewWidthConstraint = weakSelf.socialLoginStackViewWidthConstraint {
+                    weakSelf.socialLoginStackView.removeConstraint(socialLoginStackViewWidthConstraint)
+                }
+                weakSelf.socialLoginStackViewWidthConstraint = weakSelf.socialLoginStackView.widthAnchor.constraint(equalToConstant: 120)
+                weakSelf.socialLoginStackViewWidthConstraint.isActive = true
             } else {
                 weakSelf.emailField.isHidden = true
                 weakSelf.emailField.entryView.isEnabled = false
+                // Show Facebook button on Login screen
+                weakSelf.facebookLoginButton.isHidden = false
+                if let socialLoginStackViewWidthConstraint = weakSelf.socialLoginStackViewWidthConstraint {
+                    weakSelf.socialLoginStackView.removeConstraint(socialLoginStackViewWidthConstraint)
+                }
+                weakSelf.socialLoginStackViewWidthConstraint = weakSelf.socialLoginStackView.widthAnchor.constraint(equalToConstant: 190)
+                weakSelf.socialLoginStackViewWidthConstraint.isActive = true
             }
         }
         self.viewModel.outputs.passwordRepeatFieldVisibility.observeValues {[weak self] value in


### PR DESCRIPTION
Working on Issue #1084 

I'm used the existing logic to show/hide the email field if it is on register/login screen.

If in register screen, will hide the FB button and remove the old StackView constraints, then add new width constraints considering only 2 social register buttons (Apple and Google).

If in login screen, show the FB button, remove old StackView constraints and add new width considering 3 social login buttons.

Demo below:

https://user-images.githubusercontent.com/7276421/138528516-f7b0d211-ebba-45f1-bd44-c95bbfc419a4.mp4

---

my Habitica User-ID: ccf1ce82-1e91-4dd1-9b17-aa4fc4c4f2f2
