### PR TITLE
Modify HabiticaStyler for image markdown to use max width/height

### DIFF
--- a/HabitRPG/Extensions/Down-Extensions.swift
+++ b/HabitRPG/Extensions/Down-Extensions.swift
@@ -259,7 +259,8 @@ private class HabiticaStyler: DownStyler {
     override func style(image str: NSMutableAttributedString, title: String?, url: String?) {
         if let imageURL = URL(string: url ?? ""), let data = try? Data(contentsOf: imageURL) {
             let attachment = NSTextAttachment()
-            attachment.image = UIImage(data: data)
+            let resizableImage = UIImage(data: data)
+            attachment.image = resizableImage?.resize(maxWidthHeight: 200)
             let addedString = NSAttributedString(attachment: attachment)
             str.replaceCharacters(in: NSRange(location: 0, length: str.length), with: addedString)
         }

--- a/HabitRPG/Extensions/UIImage-Extensions.swift
+++ b/HabitRPG/Extensions/UIImage-Extensions.swift
@@ -36,4 +36,32 @@ extension UIImage {
         }
         return nil
     }
+    
+    // Resizable UIImage with max width/height from: https://stackoverflow.com/questions/24709244/how-do-set-a-width-and-height-of-an-image-in-swift
+    func resize(maxWidthHeight: Double) -> UIImage? {
+        let actualHeight = Double(size.height)
+        let actualWidth = Double(size.width)
+        var maxWidth = 0.0
+        var maxHeight = 0.0
+
+        if actualWidth > actualHeight {
+            maxWidth = maxWidthHeight
+            let per = (100.0 * maxWidthHeight / actualWidth)
+            maxHeight = (actualHeight * per) / 100.0
+        } else {
+            maxHeight = maxWidthHeight
+            let per = (100.0 * maxWidthHeight / actualHeight)
+            maxWidth = (actualWidth * per) / 100.0
+        }
+
+        let hasAlpha = true
+        let scale: CGFloat = 0.0
+
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: maxWidth, height: maxHeight), !hasAlpha, scale)
+        self.draw(in: CGRect(origin: .zero, size: CGSize(width: maxWidth, height: maxHeight)))
+
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        
+        return scaledImage
+    }
 }


### PR DESCRIPTION
Work related to #1012 

The images inserted via markdown are styled in the `HabiticaStyler`, `func style(image`.

In order to set a max width/height for the images, I am using a UIImage extension that resizes the image's either width or height (according to the image) to the given max value, maintaining the aspect ratio.

I set maxWidthHeight to 200, but this is arbitrary.

---

my Habitica User-ID: ccf1ce82-1e91-4dd1-9b17-aa4fc4c4f2f2
