### PR TITLE
:bug: fix sprites on EquipmentCell with no equipment

### DIFF
--- a/HabitRPG/UI/Social/UserProfileViewController.swift
+++ b/HabitRPG/UI/Social/UserProfileViewController.swift
@@ -350,6 +350,7 @@ class UserProfileViewController: BaseTableViewController {
             detailTextLabel?.textColor = ThemeService.shared.theme.primaryTextColor
             attributeLabel?.text = gear?.statsText
         } else {
+            imageView?.setImagewith(name: "")
             detailTextLabel?.text = L10n.Equipment.nothingEquipped
             detailTextLabel?.textColor = ThemeService.shared.theme.dimmedTextColor
             attributeLabel?.text = nil


### PR DESCRIPTION
issue #1155

I solved the problem on the front by setting the image to empty when there was no equipment, but it seems to be occurring a bit of a mess with the `NetworkImage` class, that I tried to understand but thought that it was better if I didn't mess around with it at this point. If I can understand it better, I'll create an issue detailing it!!

Sorry if the app is in Portuguese 😅 

---
### Some Results
#### Before
<img src="https://user-images.githubusercontent.com/68664329/164134985-da60b7d4-05a9-421f-a4ef-a910392eb876.png"  height="500">

#### After
<img src="https://user-images.githubusercontent.com/68664329/164134840-62bb6047-4f2d-4e3d-8f48-4909bb6cb93e.png"  height="500">

my Habitica User-ID: a2d130a1-9e1f-49a3-9d8b-40acb2edf889

---

Another bug that I found and did not want to group with this one is when some gears are the base, that I imagine not to be actual gears (as the ones with the "base_0" ending), since they have a `name` the cell tries to build it as a piece of equipment but fails and some of the UI is different than it should (text color and translation). To solve it just ignore the gears with the `base_0` ending or those similars would do.

