### PR TITLE
[Issue #1223] Fix pet hatching share

### DIFF
--- a/HabitRPG/UI/Inventory/ItemsViewController.swift
+++ b/HabitRPG/UI/Inventory/ItemsViewController.swift
@@ -198,7 +198,7 @@ class ItemsViewController: BaseTableViewController {
         imageAlert.addAction(title: L10n.equip, isMainAction: true) {[weak self] _ in
             self?.inventoryRepository.equip(type: "pet", key: "\(egg.key ?? "")-\(potion.key ?? "")").observeCompleted {}
         }
-        imageAlert.addAction(title: L10n.share) { (_) in
+        imageAlert.addAction(title: L10n.share, closeOnTap: false) { (_) in
             SharingManager.share(identifier: "hatchedPet", items: [
                     L10n.Inventory.hatchedSharing(egg.text ?? "", potion.text ?? "")
                 ], presentingViewController: imageAlert, sourceView: nil)

--- a/HabitRPG/Views/PetHatchingDialog.swift
+++ b/HabitRPG/Views/PetHatchingDialog.swift
@@ -197,7 +197,7 @@ class PetHatchingAlertController: HabiticaAlertController {
         imageAlert.addAction(title: L10n.equip, isMainAction: true) {[weak self] _ in
             self?.inventoryRepository.equip(type: "pet", key: "\(egg.key ?? "")-\(potion.key ?? "")").observeCompleted {}
         }
-        imageAlert.addAction(title: L10n.share) { (_) in
+        imageAlert.addAction(title: L10n.share, closeOnTap: false) { (_) in
             SharingManager.share(identifier: "hatchedPet", items: [
                     L10n.Inventory.hatchedSharing(egg.text ?? "", potion.text ?? "")
                 ], presentingViewController: imageAlert, sourceView: nil)


### PR DESCRIPTION
Fix #1223 

**Change:** Set `closeOnTap` when adding action, which defaults to true. Closing when attempting to share was the reason presenting the share sheet was failing.

my Habitica User-ID: @miller4147