### PR TITLE
[1185] Bugfix: Fix Experience Bar Overflow

### DIFF
--- a/HabitRPG/Views/ProgressBar.swift
+++ b/HabitRPG/Views/ProgressBar.swift
@@ -13,7 +13,8 @@ struct ProgressBarUI<V>: View where V: BinaryFloatingPoint {
     let value: V
     
     init(value: V, maxValue: V = 1.0) {
-        self.value = value / maxValue
+        // Cap progressBar value at maxValue to avoid overflow
+        self.value = min(value, maxValue) / maxValue
     }
     
     var body: some View {


### PR DESCRIPTION
Fix https://github.com/HabitRPG/habitica-ios/issues/1185

Change: Apply min to the value set on the ProgressBar UI component to prevent the bar overflowing over the end of the intended size of the component. Fixes the specific issue reported on the **Party member view**, and would generally fix any other instances that could occur with this ProgressBar component as well.

my Habitica User-ID: @miller4147