### PR TITLE
Fix crash when opening a guild link

### DIFF
--- a/HabitRPG/UI/General/HabiticaSplitViewController.swift
+++ b/HabitRPG/UI/General/HabiticaSplitViewController.swift
@@ -61,7 +61,7 @@ class HabiticaSplitViewController: BaseUIViewController, UIScrollViewDelegate {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        if isInitialSetup && viewID != nil {
+        if isViewLoaded && isInitialSetup && viewID != nil {
             isInitialSetup = false
             setupSplitView(traitCollection)
             if !showAsSplitView {


### PR DESCRIPTION
Closes #1267.

The app was crashing when opening a guild link because an IBOutlet on [HabiticaSplitViewController.swift](https://github.com/HabitRPG/habitica-ios/blob/a886a63330923d7f55f8493d920fd1c9615a0dfb/HabitRPG/UI/General/HabiticaSplitViewController.swift#L93) was accessed before it was loaded:
![Screenshot 2023-01-19 at 12 49 34](https://user-images.githubusercontent.com/1958175/213522249-596a14d1-bba0-4549-bc03-d7a8a9922d22.png)

This sometimes happened because of a race condition.
When handling a guild link, and instance of `SplitSocialViewController` is created, and the property `groupID` is set.

https://github.com/HabitRPG/habitica-ios/blob/a886a63330923d7f55f8493d920fd1c9615a0dfb/HabitRPG/Utilities/RouterHandler.swift#L70-L74

The property has a `didSet` property observer that dispatches a call to `viewDidLayoutSubviews` to the main thread.
Most of the time, this call was executed before the view had a chance to be loaded and the IBOutles were connected. Thus crashing as soon as one of the outlet was accessed.

https://github.com/HabitRPG/habitica-ios/blob/a886a63330923d7f55f8493d920fd1c9615a0dfb/HabitRPG/UI/Social/SplitSocialViewController.swift#L24-L34

This PR fixes the crash by adding an extra check inside the `viewDidLayoutSubviews` method, to make sure IBOutles are not accessed before the view has been loaded.

---
Habitica User-ID: `2cedef5a-666a-484b-bd97-726209679923`