### PR TITLE
Micro-optimization in challenge list to reduce GUI overdrawing

### DIFF
--- a/HabitRPG/TableviewCells/Challenges/ChallengeTableViewCell.swift
+++ b/HabitRPG/TableviewCells/Challenges/ChallengeTableViewCell.swift
@@ -34,6 +34,11 @@ class ChallengeTableViewCell: UITableViewCell {
         summaryLabel.textColor = ThemeService.shared.theme.secondaryTextColor
         memberCountLabel.textColor = ThemeService.shared.theme.secondaryTextColor
         
+        prizeLabel.backgroundColor = ThemeService.shared.theme.contentBackgroundColor
+        nameLabel.backgroundColor = ThemeService.shared.theme.contentBackgroundColor
+        summaryLabel.backgroundColor = ThemeService.shared.theme.contentBackgroundColor
+        memberCountLabel.backgroundColor = ThemeService.shared.theme.contentBackgroundColor
+        
         officialBadge.textColor = UIColor.white
         participatingBadge.textColor = UIColor.white
         ownerBadge.textColor = UIColor.white


### PR DESCRIPTION
Introduced micro-optimization in the challenge list by setting the cell labels' background color to be the same as its parent component (table view), in order to minimize overdrawing. Now, when the table cells and its labels are rendered, the underlying pixels that are covered by the labels will already have the same color as the table view background, reducing the need for additional drawing operations.

Results of the micro-optimization is depicted with Color Blended Layers utility in debug mode (red means overdrawing):
<img width="357" alt="Screenshot 2023-05-17 alle 10 33 19 PM" src="https://github.com/HabitRPG/habitica-ios/assets/68709227/65275b3a-ab19-4b9d-8f00-799369aefd38">


my Habitica User-ID: aeb2467a-11d2-4a9e-b1eb-c4120142d38e
