### PR TITLE
Fix notes section on rewards does not expand and gets cut off

### DIFF
--- a/HabitRPG/TableViewDataSources/RewardViewDataSource.swift
+++ b/HabitRPG/TableViewDataSources/RewardViewDataSource.swift
@@ -34,21 +34,6 @@ class RewardViewDataSource: BaseReactiveCollectionViewDataSource<BaseRewardProto
         }).start())
     }
     
-    override func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if isCustomRewardsSection(indexPath.section) {
-            return CGSize(width: self.collectionView?.frame.size.width ?? 0, height: 70)
-        } else {
-            return CGSize(width: 90, height: 120)
-        }
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        if isCustomRewardsSection(section) {
-            return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        } else {
-            return UIEdgeInsets(top: 10, left: 4, bottom: 10, right: 4)        }
-    }
-    
     func isCustomRewardsSection(_ section: Int) -> Bool {
         if let item = item(at: IndexPath(row: 0, section: section)) {
             if item as? TaskProtocol != nil {

--- a/HabitRPG/TableviewCells/CustomRewardCell.swift
+++ b/HabitRPG/TableviewCells/CustomRewardCell.swift
@@ -67,6 +67,7 @@ class CustomRewardCell: UICollectionViewCell {
         mainRewardWrapper.backgroundColor = theme.windowBackgroundColor
         titleLabel.textColor = theme.primaryTextColor
         notesLabel.textColor = theme.ternaryTextColor
+        notesLabel.numberOfLines = 0
     }
     
     @objc


### PR DESCRIPTION
Closes #1301 

my Habitica User-ID: 76ec69ee-f02d-4b55-b622-c0d8e381d155

---

Hello 👋 happy to make my first contribution to the project.

Changes:
- Replaces `sizeForItemAt` and `insetForSectionAt` collection view methods for a `UICollectionViewCompositionalLayout `
- Set number of lines of `CustomRewardCell` to zero so it's expandable

> **Note**: 
> When rotating the iPhone I notice this bug in production, this is also fixed in this pull request
> <img width=30% src="https://github.com/HabitRPG/habitica-ios/assets/38385635/cd7354ba-5cfb-416d-8feb-a6fe0eecd6e8">

#### Demo

| Multiple Lines |
| -------------  |
|<video src="https://github.com/HabitRPG/habitica-ios/assets/38385635/9a5a2fbc-4b76-4d5a-9a88-ff6861577877"> |

| iPhone 8 | iPhone 14 |
| --------- | ---------- |
| <video src="https://github.com/HabitRPG/habitica-ios/assets/38385635/3a26ac38-95c3-497b-bd19-3a1f3187c5de"> | <video src="https://github.com/HabitRPG/habitica-ios/assets/38385635/58fd4395-b42a-447c-b6f3-ec91d573ff6c"> | 

| iPad Mini | iPad Pro |
| --------- | -------- |
|![(6th generation)](https://github.com/HabitRPG/habitica-ios/assets/38385635/baabfa4b-46dc-4c42-abf7-a3796dd84b1b)![iPad mini (6th generation)](https://github.com/HabitRPG/habitica-ios/assets/38385635/da859304-2175-432a-9ef2-028bf72c73f0)|![iPad Pro (12 9-inch) (5th generation)](https://github.com/HabitRPG/habitica-ios/assets/38385635/a67cb184-6710-4486-a58f-695158337e67)![iPad Pro (12 9-inch) (5th generation)](https://github.com/HabitRPG/habitica-ios/assets/38385635/b74697db-3dea-4c4d-b554-7759327c8c3e)|