### PR TITLE
#1316: Show mount pixel art on bottom sheet

### DIFF
--- a/HabitRPG/UI/Inventory/Stable/MountDetailViewController.swift
+++ b/HabitRPG/UI/Inventory/Stable/MountDetailViewController.swift
@@ -43,7 +43,7 @@ class MountDetailViewController: StableDetailViewController<MountDetailDataSourc
     }
     
     private func showActionSheet(forStableItem stableItem: MountStableItem, withSource sourceView: UIView?) {
-        let sheet = HostingBottomSheetController(rootView: BottomSheetMenu(Text(stableItem.mount?.text ?? ""), iconName: "stable_Mount-Icon-\(stableItem.mount?.key ?? "")", menuItems: {
+        let sheet = HostingBottomSheetController(rootView: BottomSheetMenu(Text(stableItem.mount?.text ?? ""), iconName: "stable_Mount_Icon_\(stableItem.mount?.key ?? "")", menuItems: {
             BottomSheetMenuitem(title: user?.items?.currentMount == stableItem.mount?.key ? L10n.unequip : L10n.equip) {[weak self] in
                 self?.inventoryRepository.equip(type: "mount", key: stableItem.mount?.key ?? "").observeCompleted {}
             }


### PR DESCRIPTION

my Habitica User-ID: e8160fe6-2e6d-494f-b7db-60befa34fe8a

The source of the issue was `-` vs. `_`. I noticed that with pets the urls use `-` but with mounts we use `_`. I would recommend speaking with the backend team and have these urls be consistent 

Examples: 

Pet --> `https://habitica-assets.s3.amazonaws.com/mobileApp/images/stable_Pet-Wolf-Veteran.png`

Mounts:
Does not work --> `https://habitica-assets.s3.amazonaws.com/mobileApp/images/stable_Mount-Icon-Gryphon-RoyalPurple.png`

Does work with this PR --> `https://habitica-assets.s3.amazonaws.com/mobileApp/images/stable_Mount_Icon_Gryphon-RoyalPurple.png`
