### PR TITLE
Fixes #1299 - VoiceOver streak value for Habits/Dailies

### DIFF
--- a/HabitRPG/TableviewCells/TaskTableViewCell.swift
+++ b/HabitRPG/TableviewCells/TaskTableViewCell.swift
@@ -128,7 +128,7 @@ class TaskTableViewCell: UITableViewCell, UITextViewDelegate {
         self.accessibilityWrapper.shouldGroupAccessibilityChildren = true
         self.accessibilityWrapper.isAccessibilityElement = true
         self.accessibilityWrapper.accessibilityHint = L10n.Accessibility.doubleTapToEdit
-        self.accessibilityWrapper.accessibilityLabel = "\(task.text ?? ""), Value: \(String.forTaskQuality(task: task))"
+        self.accessibilityWrapper.accessibilityLabel = "\(task.text ?? ""), Value: \(String.forTaskQuality(task: task)), Streak: \(taskDetailLine.accessibilityText)"
         if let notes = task.notes, !notes.isEmpty {
             self.accessibilityWrapper.accessibilityLabel = "\(self.accessibilityWrapper.accessibilityLabel ?? ""), \(notes)"
         }

--- a/HabitRPG/Views/AchievementAlertController.swift
+++ b/HabitRPG/Views/AchievementAlertController.swift
@@ -119,7 +119,6 @@ class AchievementAlertController: HabiticaAlertController {
              HabiticaNotificationType.achievementDustDevil.rawValue,
              HabiticaNotificationType.achievementAridAuthority.rawValue,
              HabiticaNotificationType.achievementMonsterMagus.rawValue,
-             HabiticaNotificationType.achievementMonsterMagus.rawValue,
              HabiticaNotificationType.achievementUndeadUndertaker.rawValue,
              HabiticaNotificationType.achievementPrimedForPainting.rawValue,
              HabiticaNotificationType.achievementPearlyPro.rawValue,

--- a/HabitRPG/Views/TaskDetailLineView.swift
+++ b/HabitRPG/Views/TaskDetailLineView.swift
@@ -34,6 +34,10 @@ class TaskDetailLineView: UIView {
         return view
     }()
     
+    var accessibilityText: String {
+        streakLabel.text?.replacingOccurrences(of: " | ", with: ", ") ?? ""
+    }
+    
     private var iconColor: UIColor {
         return ThemeService.shared.theme.ternaryTextColor
     }


### PR DESCRIPTION
Added "Streak: <value>" to the accessibility label for TaskTableViewCells to allow VoiceOver to communicate streak status for dailies and habits. Also, removed duplicated line preventing code from running.

Links to [#1299](https://github.com/HabitRPG/habitica-ios/issues/1299)

my Habitica User-ID: a20d504d-8754-454d-9319-650c81de5e7c
