### PR TITLE
Fix challenge sort order to match the server-side ordering.

### DIFF
--- a/Habitica Database/Habitica Database/Repositories/SocialLocalRepository.swift
+++ b/Habitica Database/Habitica Database/Repositories/SocialLocalRepository.swift
@@ -310,7 +310,7 @@ public class SocialLocalRepository: BaseLocalRepository {
             query = RealmChallenge.findAll()
         }
         // swiftlint:disable:next force_unwrapping
-        return query!.sorted(key: "memberCount", ascending: false).reactive().map({ (value, changeset) -> ReactiveResults<[ChallengeProtocol]> in
+        return query!.sorted(by: [SortDescriptor(keyPath: "official", ascending: false), SortDescriptor(keyPath: "createdAt", ascending: false)]).reactive().map({ (value, changeset) -> ReactiveResults<[ChallengeProtocol]> in
             return (value.map({ (challenge) -> ChallengeProtocol in return challenge }), changeset)
         })
     }


### PR DESCRIPTION
The iOS app was sorting the challenges by decreasing member count, but the server returns challenges [in order of creation date](https://github.com/HabitRPG/habitica/blob/ff0bb9d005fba2b5fa04bbb79db23b12e46b223b/website/server/libs/challenges/index.js#L161) (with official challenges overriding the ordering). This mismatch seems to be what's causing #1307; my initial tests with this fix don't show the list jumping around anymore.

Fixes #1307.

My Habitica User-ID: 32f74d6d-f010-473c-9527-da0bc5914ac8