### PR TITLE
Fix reminder times showing with no timezone set

### DIFF
--- a/Habitica API Client/Habitica API Client/Models/Tasks/APIReminder.swift
+++ b/Habitica API Client/Habitica API Client/Models/Tasks/APIReminder.swift
@@ -23,10 +23,50 @@ class APIReminder: ReminderProtocol, Codable {
         case time
     }
     
+    // Encodes dates as local time with 'Z' suffix (handles timezone changes as well)
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.timeZone = TimeZone.current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        
+        if let startDate = startDate {
+            try container.encode(formatter.string(from: startDate), forKey: .startDate)
+        }
+        
+        if let time = time {
+            try container.encode(formatter.string(from: time), forKey: .time)
+        }
+    }
+    
     init(_ reminderProtocol: ReminderProtocol) {
         id = reminderProtocol.id
         startDate = reminderProtocol.startDate
         time = reminderProtocol.time
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        startDate = try decodeLocalTimeWithZSuffix(from: container, forKey: .startDate)
+        time = try decodeLocalTimeWithZSuffix(from: container, forKey: .time)
+    }
+    
+    private func decodeLocalTimeWithZSuffix(from container: KeyedDecodingContainer<CodingKeys>, 
+                                           forKey key: CodingKeys) throws -> Date? {
+        if let dateString = try? container.decode(String.self, forKey: key),
+           dateString.hasSuffix("Z") && dateString.contains(".") {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+            formatter.timeZone = TimeZone.current
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            return formatter.date(from: dateString.replacingOccurrences(of: "Z", with: ""))
+        }
+        
+        return try container.decodeIfPresent(Date.self, forKey: key)
     }
     
     func detached() -> ReminderProtocol {


### PR DESCRIPTION
Fixes reminder times displaying with offset when set on Android and viewed on iOS (ex: 10:17 AM showing as 3:17 AM).

Also ensures iOS-set reminders display correctly on Android by using a compatible date format
