### PR TITLE
Use en_US_POSIX format

### DIFF
--- a/Habitica API Client/Habitica API Client/Tasks/RetrieveTasksCall.swift
+++ b/Habitica API Client/Habitica API Client/Tasks/RetrieveTasksCall.swift
@@ -16,11 +16,13 @@ public class RetrieveTasksCall: ResponseArrayCall<TaskProtocol, APITask> {
         if let date = dueOnDay {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone.current
             var dateString = formatter.string(from: date)
             let regex = try? NSRegularExpression(pattern: "T([0-9]):", options: .caseInsensitive)
             dateString = regex?.stringByReplacingMatches(in: dateString, options: [], range: NSRange(location: 0, length: dateString.count), withTemplate: "T0$1:") ?? ""
-            url = "\(url)?type=dailys&dueDate=\(dateString)"
-            url = url.replacingOccurrences(of: "+", with: "%2B")
+            let encodedDateString = dateString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? dateString
+            url = "\(url)?type=dailys&dueDate=\(encodedDateString)"
         }
         if let type = type {
             url = "\(url)?type=\(type)"


### PR DESCRIPTION
Players with non-English device locales (e.g. Japanese) were unable to set dailies due to date formatting issues. The API was receiving locale-specific date formats that it couldn't parse.

Set formatter locale to en_US_POSIX for consistent date formatting