### PR TITLE
Fix monthly weekly task appearing as due every day (#1266)

### DIFF
--- a/HabitRPG/UI/Tasks/TaskFormView.swift
+++ b/HabitRPG/UI/Tasks/TaskFormView.swift
@@ -632,13 +632,27 @@ class TaskFormViewModel: ObservableObject {
     }
 }
 
+extension Calendar {
+    /// Returns which occurrence of the weekday this date is in the month.
+    /// Examples:
+    ///   - Jan 1, 2025 (first Wednesday) → returns 1
+    ///   - Jan 8, 2025 (second Wednesday) → returns 2
+    ///   - Jan 29, 2025 (fifth Wednesday) → returns 5
+    func weekdayOrdinal(for date: Date) -> Int {
+        let formatter = DateFormatter()
+        formatter.calendar = self
+        formatter.dateFormat = "F"  // "F" means weekday ordinal (1-5)
+        return Int(formatter.string(from: date)) ?? 1
+    }
+}
+
 struct DailyProgressView: View {
     let history: [TaskHistoryProtocol]
-    
+
     private let theme = ThemeService.shared.theme
     private let today = Date()
     private let calendar = Calendar.current
-    
+
     private let gray = Color(UIColor.gray400)
     
     @State private var dayItemHeight: CGFloat = 40
@@ -1046,7 +1060,7 @@ class TaskFormController: UIHostingController<TaskFormView> {
         
         if let startDate = task.startDate {
             if viewModel.dayOrWeekMonth == "week" {
-                task.weeksOfMonth.append(Calendar.current.component(.weekOfMonth, from: startDate)-1)
+                task.weeksOfMonth.append(Calendar.current.weekdayOrdinal(for: startDate))
             } else {
                 task.daysOfMonth.append(Calendar.current.component(.day, from: startDate))
             }


### PR DESCRIPTION
## Summary
Fixes #1266 where daily tasks set to repeat monthly on a specific weekday occurrence (e.g., "3rd Tuesday of every month") were incorrectly appearing as due every day instead of just once per month.

## Root Cause
The bug was in `TaskFormView.swift` line 1049 (now line 1063). The code was using `Calendar.component(.weekOfMonth, from: startDate) - 1` which:
1. Uses `.weekOfMonth` that returns which week of the month a date is in (1-6), not which occurrence of a specific weekday
2. Subtracts 1 to convert to 0-indexed values
3. Produces incorrect values, especially problematic when the month starts on the target weekday (resulting in `1 - 1 = 0`, which is invalid)

**Example of the bug:**
- User selects January 1, 2025 (first Wednesday of the month) 
- Old code: `weekOfMonth(1) - 1 = 0` ❌ (invalid, causes server to miscalculate and show task as due every day)
- New code: `weekdayOrdinal = 1` ✅ (correctly indicates 1st occurrence)

## Solution
Use DateFormatter pattern "F" to get the weekday ordinal (1-5) which correctly represents which occurrence of that specific weekday it is in the month. This matches what the Habitica server expects in the `weeksOfMonth` array.

## Changes
- Added `Calendar.weekdayOrdinal(for:)` extension method that uses DateFormatter pattern "F"
- Fixed line 1063 to use `Calendar.current.weekdayOrdinal(for: startDate)` instead of the buggy calculation

## Testing
- Swift syntax validation passes
- Code follows the existing pattern used in `TaskRepeatablesSummaryInteractor.swift` which already uses DateFormatter pattern "FEEEE" for display
- Existing test `TaskRepeatablesSummaryInteractorTests.swift:163-164` expects `weeksOfMonth = [5]` for "5 Tuesday", confirming server expects 1-indexed values (1-5)

## Habitica User ID
`@zazy0`