### PR TITLE
[Bug Fix] Fix Sound When Leveling Up

### DIFF
--- a/HabitRPG/Utilities/SoundManager.swift
+++ b/HabitRPG/Utilities/SoundManager.swift
@@ -115,7 +115,7 @@ enum SoundTheme: String, EquatableStringEnumProtocol {
     }
 }
 
-class SoundManager {
+class SoundManager: NSObject {
     
     public static let shared = SoundManager()
     
@@ -126,6 +126,9 @@ class SoundManager {
             }
         }
     }
+
+    private let soundQueue: DispatchQueue
+    private var players: [URL: AVAudioPlayer]
     private var player: AVAudioPlayer?
     
     private var soundsDirectory: URL? {
@@ -142,37 +145,53 @@ class SoundManager {
         return nil
     }
     
-    private init() {
+    private override init() {
+        soundQueue = .init(label: "com.habitica.soundqueue")
+        players = [:]
+        super.init()
+
+        // Set current theme
         let defaults = UserDefaults.standard
         currentTheme = SoundTheme(rawValue: defaults.string(forKey: "soundTheme") ?? "") ?? SoundTheme.none
+
+        // Set up audio session
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
+        } catch {
+            logger.log(error.localizedDescription)
+        }
     }
     
     func play(effect: SoundEffect) {
         if currentTheme == SoundTheme.none {
             return
         }
-        let queue = DispatchQueue(label: "sound", attributes: .concurrent)
-        queue.async {[weak self] in
+        soundQueue.async(qos: .userInitiated) { [weak self] in
             do {
-                guard let theme = self?.currentTheme.rawValue else {
+                guard let self = self else {
                     return
                 }
-                guard let url = self?.soundsDirectory?.appendingPathComponent("\(theme)/\(effect.rawValue).mp3") else {
+
+                // Make sure sound file exists
+                let theme = self.currentTheme.rawValue
+                guard let url = self.soundsDirectory?.appendingPathComponent("\(theme)/\(effect.rawValue).mp3"),
+                      FileManager.default.fileExists(atPath: url.path) else {
                     return
                 }
-                
-                if !FileManager.default.fileExists(atPath: url.path) {
+
+                // Get an audio player
+                guard let player = try self.getPlayerWithURL(url) else {
                     return
                 }
-                
-                try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
-                try AVAudioSession.sharedInstance().setActive(true)
-                self?.player = try? AVAudioPlayer(contentsOf: url, fileTypeHint: AVFileType.mp3.rawValue)
-                
-                guard let player = self?.player else {
-                    return
+
+                // Reset player if already playing sound
+                if player.isPlaying {
+                    player.pause()
+                    player.currentTime = 0
                 }
-                
+
+                // Play sound
+                player.prepareToPlay()
                 player.play()
             } catch let error {
                 logger.log(error.localizedDescription)
@@ -180,6 +199,17 @@ class SoundManager {
         }
     }
     
+    private func getPlayerWithURL(_ url: URL) throws -> AVAudioPlayer? {
+        var player: AVAudioPlayer? = players[url]
+        if player == nil {
+            // Create new audio player
+            player = try AVAudioPlayer(contentsOf: url, fileTypeHint: AVFileType.mp3.rawValue)
+            player?.delegate = self
+            players[url] = player
+        }
+        return player
+    }
+
     private func loadAllFiles() {
         if currentTheme == SoundTheme.none {
             return
@@ -222,5 +252,23 @@ class SoundManager {
             }
         }
         task.resume()
+    }
+}
+
+extension SoundManager: AVAudioPlayerDelegate {
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        removePlayerWithURL(player.url)
+    }
+
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: (any Error)?) {
+        logger.log("Failure: \(error?.localizedDescription ?? "")")
+        removePlayerWithURL(player.url)
+    }
+
+    private func removePlayerWithURL(_ url: URL?) {
+        if let url = url {
+            players[url] = nil
+        }
     }
 }


### PR DESCRIPTION
## Habitica User-ID
`Night-Knight`

## Summary
Fixes #1182 where a user reported that a sound does not play when they level up, but it does play on other platforms (i.e. Web, Android).

## Root Cause
In `SoundManager.swift`, a new audio player is created each time a sound is played. The "Level Up" sound begins to play but is immediately replaced with the sound passed into `TaskTableViewDataSource`. So for example, if a user taps "+" on a habit and levels up, the "Habit Positive / Negative" sound overrides the "Level Up" sound.

## Solution
Create a new audio player for each unique sound file, and store them in a dictionary while the sound is playing. Once the sound is finished playing, release the audio player. If a new sound is played while a different sound is playing, they will overlap. If the user initiates a sound while it is currently playing, restart the sound.

Also, create one class `DispatchQueue` to play the sounds instead of creating a new queue each time.

## Testing
1. Tap "+ / -" on a habit until you level up
2. Observe that the "Habit Positive / Negative" sound restarts if the button is pressed repeatedly
3. Observe that the "Habit Positive / Negative" and "Level Up" sounds play simultaneously if you level up